### PR TITLE
feat: support env values in chart

### DIFF
--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: notifications
 description: Helm chart for the agynio notifications gRPC service
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0

--- a/charts/notifications/templates/deployment.yaml
+++ b/charts/notifications/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - name: grpc
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             tcpSocket:

--- a/charts/notifications/values.yaml
+++ b/charts/notifications/values.yaml
@@ -5,6 +5,8 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+env: []
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary
- add optional env block to deployment template
- expose env values array defaulting to [] and bump chart/app version to 0.2.0

## Testing
- helm lint charts/notifications
- helm template charts/notifications
- make proto
- go build ./...
- go test ./...

Closes #9