### PR TITLE
Release v0.2.1 multi-arch notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -32,6 +34,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/agynio/notifications:edge
 
@@ -46,6 +49,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22.x'
+
+      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -93,6 +98,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/agynio/notifications:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
 
 ENV CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64 \
     GOBIN=/usr/local/bin
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -11,7 +13,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://github.com/bufbuild/buf/releases/download/v1.64.0/buf-Linux-x86_64.tar.gz \
+RUN set -e; \
+    build_arch="${BUILDARCH:-${TARGETARCH}}"; \
+    if [ "$build_arch" = "arm64" ]; then \
+      buf_arch="aarch64"; \
+    else \
+      buf_arch="x86_64"; \
+    fi; \
+    curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.64.0/buf-Linux-${buf_arch}.tar.gz" \
       | tar -xzf - -C /usr/local --strip-components=1 buf/bin/buf
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.2 && \
@@ -27,7 +36,7 @@ COPY . .
 RUN buf export buf.build/agynio/api --output internal/.proto && \
     buf generate internal/.proto --template ./buf.gen.yaml
 
-RUN go build -o /out/notifications ./cmd/notifications
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/notifications ./cmd/notifications
 
 FROM gcr.io/distroless/static-debian12
 

--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: notifications
 description: Helm chart for the agynio notifications gRPC service
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.2.1
+appVersion: 0.2.1


### PR DESCRIPTION
## Summary
- enable multi-arch buildx publishing for edge and release images
- make the Dockerfile buildx-aware for cross-platform builds
- bump the notifications chart version/appVersion to 0.2.1

## Testing
- PATH=/workspace/notifications/bin:$PATH make test
- PATH=/workspace/notifications/bin:$PATH make lint

## Issue
- #88