### PR TITLE
fix(redis): add startup retry backoff

### DIFF
--- a/cmd/notifications/main.go
+++ b/cmd/notifications/main.go
@@ -23,6 +23,13 @@ import (
 	"github.com/agynio/notifications/internal/stream"
 )
 
+const (
+	redisRetryMaxAttempts    = 15
+	redisRetryInitialBackoff = 500 * time.Millisecond
+	redisRetryMaxBackoff     = 5 * time.Second
+	redisPingTimeout         = 3 * time.Second
+)
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "notifications service failed: %v\n", err)
@@ -59,7 +66,7 @@ func run() error {
 	})
 	defer func() { _ = subClient.Close() }()
 
-	if err := ensureRedis(ctx, pubClient); err != nil {
+	if err := ensureRedis(ctx, logger, pubClient); err != nil {
 		return err
 	}
 
@@ -135,11 +142,58 @@ func run() error {
 	return nil
 }
 
-func ensureRedis(ctx context.Context, client *redis.Client) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := client.Ping(ctx).Err(); err != nil {
-		return fmt.Errorf("redis ping: %w", err)
+func ensureRedis(ctx context.Context, logger *zap.Logger, client *redis.Client) error {
+	backoff := redisRetryInitialBackoff
+	var lastErr error
+	for attempt := 1; attempt <= redisRetryMaxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		pingCtx, cancel := context.WithTimeout(ctx, redisPingTimeout)
+		err := client.Ping(pingCtx).Err()
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if attempt == redisRetryMaxAttempts {
+			break
+		}
+
+		delay := backoff
+		if delay > redisRetryMaxBackoff {
+			delay = redisRetryMaxBackoff
+		}
+
+		if logger != nil {
+			logger.Warn(
+				"redis ping failed, retrying",
+				zap.Int("attempt", attempt),
+				zap.Int("max_attempts", redisRetryMaxAttempts),
+				zap.Duration("backoff", delay),
+				zap.Error(err),
+			)
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > redisRetryMaxBackoff {
+			backoff = redisRetryMaxBackoff
+		}
 	}
-	return nil
+
+	if lastErr == nil {
+		return fmt.Errorf("redis ping: unknown error")
+	}
+	return fmt.Errorf("redis ping: %w", lastErr)
 }

--- a/cmd/notifications/main.go
+++ b/cmd/notifications/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/agynio/notifications/internal/config"
 	"github.com/agynio/notifications/internal/logging"
 	redisstream "github.com/agynio/notifications/internal/redis"
+	"github.com/agynio/notifications/internal/retry"
 	"github.com/agynio/notifications/internal/server"
 	"github.com/agynio/notifications/internal/stream"
 )
@@ -143,57 +144,32 @@ func run() error {
 }
 
 func ensureRedis(ctx context.Context, logger *zap.Logger, client *redis.Client) error {
-	backoff := redisRetryInitialBackoff
-	var lastErr error
-	for attempt := 1; attempt <= redisRetryMaxAttempts; attempt++ {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+	config := retry.Config{
+		MaxAttempts:    redisRetryMaxAttempts,
+		InitialBackoff: redisRetryInitialBackoff,
+		MaxBackoff:     redisRetryMaxBackoff,
+	}
+	if err := retry.WithBackoff(ctx, config, func(ctx context.Context) error {
 		pingCtx, cancel := context.WithTimeout(ctx, redisPingTimeout)
-		err := client.Ping(pingCtx).Err()
-		cancel()
-		if err == nil {
-			return nil
+		defer cancel()
+		return client.Ping(pingCtx).Err()
+	}, func(state retry.State) {
+		if logger == nil {
+			return
 		}
-		lastErr = err
+		logger.Warn(
+			"redis ping failed, retrying",
+			zap.Int("attempt", state.Attempt),
+			zap.Int("max_attempts", state.MaxAttempts),
+			zap.Duration("backoff", state.Backoff),
+			zap.Error(state.Err),
+		)
+	}); err != nil {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if attempt == redisRetryMaxAttempts {
-			break
-		}
-
-		delay := backoff
-		if delay > redisRetryMaxBackoff {
-			delay = redisRetryMaxBackoff
-		}
-
-		if logger != nil {
-			logger.Warn(
-				"redis ping failed, retrying",
-				zap.Int("attempt", attempt),
-				zap.Int("max_attempts", redisRetryMaxAttempts),
-				zap.Duration("backoff", delay),
-				zap.Error(err),
-			)
-		}
-
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
-
-		backoff *= 2
-		if backoff > redisRetryMaxBackoff {
-			backoff = redisRetryMaxBackoff
-		}
+		return fmt.Errorf("redis ping: %w", err)
 	}
 
-	if lastErr == nil {
-		return fmt.Errorf("redis ping: unknown error")
-	}
-	return fmt.Errorf("redis ping: %w", lastErr)
+	return nil
 }

--- a/internal/redis/subscriber.go
+++ b/internal/redis/subscriber.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
+	"github.com/agynio/notifications/internal/retry"
 )
 
 const (
@@ -129,62 +130,43 @@ func (s *Subscriber) Start(ctx context.Context) error {
 }
 
 func (s *Subscriber) subscribeWithRetry(ctx context.Context) (pubSub, error) {
-	backoff := subscribeRetryInitialBackoff
-	var lastErr error
-
-	for attempt := 1; attempt <= subscribeRetryMaxAttempts; attempt++ {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
+	var pubsub pubSub
+	config := retry.Config{
+		MaxAttempts:    subscribeRetryMaxAttempts,
+		InitialBackoff: subscribeRetryInitialBackoff,
+		MaxBackoff:     subscribeRetryMaxBackoff,
+	}
+	if err := retry.WithBackoff(ctx, config, func(ctx context.Context) error {
+		current := s.client.Subscribe(ctx, s.channel)
+		if current == nil {
+			return fmt.Errorf("redis subscribe returned nil pubsub")
 		}
-
-		pubsub := s.client.Subscribe(ctx, s.channel)
-		if pubsub == nil {
-			lastErr = fmt.Errorf("redis subscribe returned nil pubsub")
-		} else if _, err := pubsub.Receive(ctx); err != nil {
-			_ = pubsub.Close()
-			lastErr = fmt.Errorf("redis receive subscription ack: %w", err)
-		} else {
-			return pubsub, nil
+		if _, err := current.Receive(ctx); err != nil {
+			_ = current.Close()
+			return fmt.Errorf("redis receive subscription ack: %w", err)
 		}
-
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		if attempt == subscribeRetryMaxAttempts {
-			break
-		}
-
-		delay := backoff
-		if delay > subscribeRetryMaxBackoff {
-			delay = subscribeRetryMaxBackoff
-		}
-
+		pubsub = current
+		return nil
+	}, func(state retry.State) {
 		s.logWarn(
 			"redis subscribe failed, retrying",
-			zap.Int("attempt", attempt),
-			zap.Int("max_attempts", subscribeRetryMaxAttempts),
-			zap.Duration("backoff", delay),
-			zap.Error(lastErr),
+			zap.Int("attempt", state.Attempt),
+			zap.Int("max_attempts", state.MaxAttempts),
+			zap.Duration("backoff", state.Backoff),
+			zap.Error(state.Err),
 		)
-
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
+	}); err != nil {
+		if ctx.Err() != nil {
 			return nil, ctx.Err()
-		case <-timer.C:
 		}
-
-		backoff *= 2
-		if backoff > subscribeRetryMaxBackoff {
-			backoff = subscribeRetryMaxBackoff
-		}
+		return nil, err
 	}
 
-	if lastErr == nil {
+	if pubsub == nil {
 		return nil, fmt.Errorf("redis subscribe failed")
 	}
-	return nil, lastErr
+
+	return pubsub, nil
 }
 
 // Stop terminates the streaming goroutine and waits for it to finish.

--- a/internal/redis/subscriber.go
+++ b/internal/redis/subscriber.go
@@ -163,7 +163,7 @@ func (s *Subscriber) subscribeWithRetry(ctx context.Context) (pubSub, error) {
 	}
 
 	if pubsub == nil {
-		return nil, fmt.Errorf("redis subscribe failed")
+		panic("subscribeWithRetry: WithBackoff succeeded but pubsub is nil")
 	}
 
 	return pubsub, nil

--- a/internal/redis/subscriber.go
+++ b/internal/redis/subscriber.go
@@ -5,12 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	redis "github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
+)
+
+const (
+	subscribeRetryMaxAttempts    = 15
+	subscribeRetryInitialBackoff = 500 * time.Millisecond
+	subscribeRetryMaxBackoff     = 5 * time.Second
 )
 
 type pubSub interface {
@@ -70,13 +77,9 @@ func (s *Subscriber) Start(ctx context.Context) error {
 		return fmt.Errorf("subscriber already started")
 	}
 
-	pubsub := s.client.Subscribe(ctx, s.channel)
-	if pubsub == nil {
-		return fmt.Errorf("redis subscribe returned nil pubsub")
-	}
-
-	if _, err := pubsub.Receive(ctx); err != nil {
-		return fmt.Errorf("redis receive subscription ack: %w", err)
+	pubsub, err := s.subscribeWithRetry(ctx)
+	if err != nil {
+		return err
 	}
 
 	streamCtx, cancel := context.WithCancel(ctx)
@@ -125,6 +128,65 @@ func (s *Subscriber) Start(ctx context.Context) error {
 	return nil
 }
 
+func (s *Subscriber) subscribeWithRetry(ctx context.Context) (pubSub, error) {
+	backoff := subscribeRetryInitialBackoff
+	var lastErr error
+
+	for attempt := 1; attempt <= subscribeRetryMaxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		pubsub := s.client.Subscribe(ctx, s.channel)
+		if pubsub == nil {
+			lastErr = fmt.Errorf("redis subscribe returned nil pubsub")
+		} else if _, err := pubsub.Receive(ctx); err != nil {
+			_ = pubsub.Close()
+			lastErr = fmt.Errorf("redis receive subscription ack: %w", err)
+		} else {
+			return pubsub, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if attempt == subscribeRetryMaxAttempts {
+			break
+		}
+
+		delay := backoff
+		if delay > subscribeRetryMaxBackoff {
+			delay = subscribeRetryMaxBackoff
+		}
+
+		s.logWarn(
+			"redis subscribe failed, retrying",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", subscribeRetryMaxAttempts),
+			zap.Duration("backoff", delay),
+			zap.Error(lastErr),
+		)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > subscribeRetryMaxBackoff {
+			backoff = subscribeRetryMaxBackoff
+		}
+	}
+
+	if lastErr == nil {
+		return nil, fmt.Errorf("redis subscribe failed")
+	}
+	return nil, lastErr
+}
+
 // Stop terminates the streaming goroutine and waits for it to finish.
 func (s *Subscriber) Stop() {
 	s.mu.Lock()
@@ -152,5 +214,11 @@ func (s *Subscriber) Messages() <-chan *notificationsv1.NotificationEnvelope {
 func (s *Subscriber) logError(msg string, err error) {
 	if s.logger != nil {
 		s.logger.Error(msg, zap.Error(err))
+	}
+}
+
+func (s *Subscriber) logWarn(msg string, fields ...zap.Field) {
+	if s.logger != nil {
+		s.logger.Warn(msg, fields...)
 	}
 }

--- a/internal/redis/subscriber_test.go
+++ b/internal/redis/subscriber_test.go
@@ -66,7 +66,8 @@ func TestSubscriber_StartAndReceive(t *testing.T) {
 func TestSubscriber_Start_ErrorOnSubscribe(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 
 	mock := &mockSubscriber{
 		sub: &mockPubSub{

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,86 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Config defines the retry limits and backoff settings.
+type Config struct {
+	MaxAttempts    int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+// State describes a failed attempt that will be retried.
+type State struct {
+	Attempt     int
+	MaxAttempts int
+	Backoff     time.Duration
+	Err         error
+}
+
+// Operation performs a retryable action.
+type Operation func(ctx context.Context) error
+
+// OnRetry is invoked after a failed attempt when another retry will occur.
+type OnRetry func(State)
+
+// WithBackoff retries the operation using exponential backoff until success,
+// context cancellation, or the maximum number of attempts is reached.
+func WithBackoff(ctx context.Context, cfg Config, operation Operation, onRetry OnRetry) error {
+	backoff := cfg.InitialBackoff
+	var lastErr error
+
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if err := operation(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+
+		delay := backoff
+		if delay > cfg.MaxBackoff {
+			delay = cfg.MaxBackoff
+		}
+
+		if onRetry != nil {
+			onRetry(State{
+				Attempt:     attempt,
+				MaxAttempts: cfg.MaxAttempts,
+				Backoff:     delay,
+				Err:         lastErr,
+			})
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > cfg.MaxBackoff {
+			backoff = cfg.MaxBackoff
+		}
+	}
+
+	if lastErr == nil {
+		return fmt.Errorf("retry failed without error")
+	}
+	return lastErr
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -30,6 +30,10 @@ type OnRetry func(State)
 // WithBackoff retries the operation using exponential backoff until success,
 // context cancellation, or the maximum number of attempts is reached.
 func WithBackoff(ctx context.Context, cfg Config, operation Operation, onRetry OnRetry) error {
+	if cfg.MaxAttempts < 1 {
+		return fmt.Errorf("retry: MaxAttempts must be >= 1, got %d", cfg.MaxAttempts)
+	}
+
 	backoff := cfg.InitialBackoff
 	var lastErr error
 
@@ -79,8 +83,5 @@ func WithBackoff(ctx context.Context, cfg Config, operation Operation, onRetry O
 		}
 	}
 
-	if lastErr == nil {
-		return fmt.Errorf("retry failed without error")
-	}
 	return lastErr
 }

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,126 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWithBackoffSucceedsAfterRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	config := Config{
+		MaxAttempts:    4,
+		InitialBackoff: 5 * time.Millisecond,
+		MaxBackoff:     20 * time.Millisecond,
+	}
+
+	attempts := 0
+	var states []State
+
+	err := WithBackoff(ctx, config, func(ctx context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("transient failure")
+		}
+		return nil
+	}, func(state State) {
+		states = append(states, state)
+	})
+
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if len(states) != 2 {
+		t.Fatalf("expected 2 retry callbacks, got %d", len(states))
+	}
+	if states[0].Attempt != 1 || states[1].Attempt != 2 {
+		t.Fatalf("unexpected retry attempts: %+v", states)
+	}
+	if states[0].Backoff != 5*time.Millisecond {
+		t.Fatalf("unexpected first backoff: %v", states[0].Backoff)
+	}
+	if states[1].Backoff != 10*time.Millisecond {
+		t.Fatalf("unexpected second backoff: %v", states[1].Backoff)
+	}
+}
+
+func TestWithBackoffReturnsLastError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	config := Config{
+		MaxAttempts:    3,
+		InitialBackoff: 5 * time.Millisecond,
+		MaxBackoff:     7 * time.Millisecond,
+	}
+
+	sentinel := errors.New("persistent failure")
+	var states []State
+	attempts := 0
+
+	err := WithBackoff(ctx, config, func(ctx context.Context) error {
+		attempts++
+		return sentinel
+	}, func(state State) {
+		states = append(states, state)
+	})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected error %q, got %v", sentinel, err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if len(states) != 2 {
+		t.Fatalf("expected 2 retry callbacks, got %d", len(states))
+	}
+	if states[0].Backoff != 5*time.Millisecond {
+		t.Fatalf("unexpected first backoff: %v", states[0].Backoff)
+	}
+	if states[1].Backoff != 7*time.Millisecond {
+		t.Fatalf("unexpected capped backoff: %v", states[1].Backoff)
+	}
+}
+
+func TestWithBackoffStopsOnCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	config := Config{
+		MaxAttempts:    2,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	}
+
+	attempts := 0
+	called := false
+
+	err := WithBackoff(ctx, config, func(ctx context.Context) error {
+		attempts++
+		return nil
+	}, func(state State) {
+		called = true
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if attempts != 0 {
+		t.Fatalf("expected no attempts, got %d", attempts)
+	}
+	if called {
+		t.Fatal("unexpected retry callback")
+	}
+}


### PR DESCRIPTION
## Summary
- add exponential backoff retries for Redis ping on startup
- add retry with backoff for Redis subscriber start
- tighten subscriber start test timeout to avoid long retry waits

## Testing
- go build ./...
- go test ./...
- go vet ./...

Closes #14