### PR TITLE
fix(chart): bump notifications to v0.2.2

### DIFF
--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: notifications
 description: Helm chart for the agynio notifications gRPC service
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.2.2
+appVersion: 0.2.2
 home: https://github.com/agynio/notifications
 sources:
   - https://github.com/agynio/notifications

--- a/charts/notifications/templates/service-base.yaml
+++ b/charts/notifications/templates/service-base.yaml
@@ -1,8 +1,15 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- bump notifications chart version/appVersion to 0.2.2
- add YAML separators between service-base template includes for valid manifests

## Testing
- go build ./...
- go test ./...
- go vet ./...
- helm lint charts/notifications

Closes #16