### PR TITLE
feat: scope notifications subscribe auth

### DIFF
--- a/cmd/notifications/main.go
+++ b/cmd/notifications/main.go
@@ -14,7 +14,9 @@ import (
 	redis "github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
 	"github.com/agynio/notifications/internal/config"
 	"github.com/agynio/notifications/internal/logging"
@@ -78,6 +80,7 @@ func run() error {
 	}
 
 	hub := stream.NewHub(cfg.StreamBufferSize, logger)
+	workloadOrgIndex := server.NewWorkloadOrgIndex()
 
 	forwardCtx, forwardCancel := context.WithCancel(ctx)
 	var forwardWG sync.WaitGroup
@@ -92,16 +95,29 @@ func run() error {
 				if !ok {
 					return
 				}
+				workloadOrgIndex.RecordEnvelope(envelope)
 				hub.Broadcast(envelope)
 			}
 		}
 	}()
+
+	authorizationConn, err := grpc.DialContext(ctx, cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		forwardCancel()
+		forwardWG.Wait()
+		subscriber.Stop()
+		return fmt.Errorf("dial authorization service: %w", err)
+	}
+	defer authorizationConn.Close()
 
 	grpcServer := grpc.NewServer()
 	notificationsv1.RegisterNotificationsServiceServer(
 		grpcServer,
 		server.New(publisher, hub, logger,
 			server.WithClock(func() time.Time { return time.Now().UTC() }),
+			server.WithAuthorizationClient(authorizationv1.NewAuthorizationServiceClient(authorizationConn)),
+			server.WithWorkloadOrgResolver(workloadOrgIndex),
+			server.WithWorkloadOrgRecorder(workloadOrgIndex),
 		),
 	)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,23 +8,25 @@ import (
 )
 
 const (
-	defaultGRPCAddr         = ":50051"
-	defaultRedisAddr        = "127.0.0.1:6379"
-	defaultRedisDB          = 0
-	defaultRedisChannel     = "notifications"
-	defaultStreamBufferSize = 64
-	defaultLogLevel         = "info"
+	defaultGRPCAddr             = ":50051"
+	defaultRedisAddr            = "127.0.0.1:6379"
+	defaultRedisDB              = 0
+	defaultRedisChannel         = "notifications"
+	defaultStreamBufferSize     = 64
+	defaultLogLevel             = "info"
+	defaultAuthorizationAddress = "authorization:50051"
 )
 
 // Config captures runtime configuration derived from the environment.
 type Config struct {
-	GRPCAddr         string
-	RedisAddr        string
-	RedisPassword    string
-	RedisDB          int
-	RedisChannel     string
-	StreamBufferSize int
-	LogLevel         string
+	GRPCAddr             string
+	RedisAddr            string
+	RedisPassword        string
+	RedisDB              int
+	RedisChannel         string
+	StreamBufferSize     int
+	LogLevel             string
+	AuthorizationAddress string
 }
 
 // Load reads configuration from environment variables, applying defaults when
@@ -35,6 +37,7 @@ func Load() (Config, error) {
 	cfg.GRPCAddr = readEnv("GRPC_ADDR", defaultGRPCAddr)
 	cfg.RedisAddr = readEnv("REDIS_ADDR", defaultRedisAddr)
 	cfg.RedisPassword = readEnv("REDIS_PASSWORD", "")
+	cfg.AuthorizationAddress = readEnv("AUTHORIZATION_ADDRESS", defaultAuthorizationAddress)
 
 	redisDBStr := readEnv("REDIS_DB", "")
 	if redisDBStr == "" {

--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -61,6 +61,16 @@ func (s *Server) authorizeSubscribe(ctx context.Context, identityID uuid.UUID, r
 			if !allowed {
 				return status.Error(codes.PermissionDenied, "permission denied")
 			}
+		case roomKindOrganization:
+			allowed, err := s.memberAllowed(ctx, identityID, room.id, memberCache)
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+		case roomKindOther:
+			return status.Error(codes.PermissionDenied, "permission denied")
 		}
 	}
 	return nil

--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
+)
+
+const (
+	identityMetadata           = "x-identity-id"
+	organizationMemberRelation = "member"
+	identityObjectPrefix       = "identity:"
+	organizationObjectPrefix   = "organization:"
+)
+
+func identityFromMetadata(ctx context.Context) (uuid.UUID, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.UUID{}, false, nil
+	}
+	values := md.Get(identityMetadata)
+	if len(values) == 0 {
+		return uuid.UUID{}, false, nil
+	}
+	if len(values) != 1 {
+		return uuid.UUID{}, true, fmt.Errorf("expected single %s", identityMetadata)
+	}
+	identityID, err := parseUUID(values[0])
+	if err != nil {
+		return uuid.UUID{}, true, err
+	}
+	return identityID, true, nil
+}
+
+func (s *Server) authorizeSubscribe(ctx context.Context, identityID uuid.UUID, rooms []subscriptionRoom) error {
+	memberCache := map[uuid.UUID]bool{}
+	for _, room := range rooms {
+		switch room.kind {
+		case roomKindThreadParticipant:
+			if room.id != identityID {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+		case roomKindWorkload:
+			if s.workloadOrgResolver == nil {
+				return status.Error(codes.Internal, "workload org resolver unavailable")
+			}
+			organizationID, ok := s.workloadOrgResolver.OrgIDForWorkload(room.id)
+			if !ok {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+			allowed, err := s.memberAllowed(ctx, identityID, organizationID, memberCache)
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) memberAllowed(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, cache map[uuid.UUID]bool) (bool, error) {
+	if allowed, ok := cache[organizationID]; ok {
+		return allowed, nil
+	}
+	allowed, err := s.relationAllowed(ctx, identityID, organizationMemberRelation, organizationObject(organizationID))
+	if err != nil {
+		return false, err
+	}
+	cache[organizationID] = allowed
+	return allowed, nil
+}
+
+func (s *Server) relationAllowed(ctx context.Context, identityID uuid.UUID, relation string, object string) (bool, error) {
+	if s.authorizationClient == nil {
+		return false, status.Error(codes.Internal, "authorization client unavailable")
+	}
+	resp, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityObject(identityID),
+			Relation: relation,
+			Object:   object,
+		},
+	})
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	return resp.GetAllowed(), nil
+}
+
+func identityObject(identityID uuid.UUID) string {
+	return identityObjectPrefix + identityID.String()
+}
+
+func organizationObject(organizationID uuid.UUID) string {
+	return organizationObjectPrefix + organizationID.String()
+}

--- a/internal/server/rooms.go
+++ b/internal/server/rooms.go
@@ -24,6 +24,7 @@ const (
 	roomKindOther roomKind = iota
 	roomKindThreadParticipant
 	roomKindWorkload
+	roomKindOrganization
 )
 
 type subscriptionRoom struct {
@@ -47,15 +48,19 @@ func parseSubscribeRooms(req *notificationsv1.SubscribeRequest) ([]subscriptionR
 		if trimmed == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "room %d is empty", i)
 		}
-		if _, ok := seen[trimmed]; ok {
-			continue
-		}
-		seen[trimmed] = struct{}{}
-		kind, id, err := classifyRoom(trimmed)
+		kind, id, canonical, err := classifyRoom(trimmed)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "room %d: %v", i, err)
 		}
-		parsed = append(parsed, subscriptionRoom{name: trimmed, kind: kind, id: id})
+		name := trimmed
+		if canonical != "" {
+			name = canonical
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		parsed = append(parsed, subscriptionRoom{name: name, kind: kind, id: id})
 	}
 	if len(parsed) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "rooms required")
@@ -74,20 +79,26 @@ func roomNames(rooms []subscriptionRoom) []string {
 	return values
 }
 
-func classifyRoom(room string) (roomKind, uuid.UUID, error) {
+func classifyRoom(room string) (roomKind, uuid.UUID, string, error) {
 	if id, matched, err := parseRoomUUID(room, threadParticipantRoomPrefix); matched {
 		if err != nil {
-			return roomKindThreadParticipant, uuid.UUID{}, fmt.Errorf("thread_participant: %w", err)
+			return roomKindThreadParticipant, uuid.UUID{}, "", fmt.Errorf("thread_participant: %w", err)
 		}
-		return roomKindThreadParticipant, id, nil
+		return roomKindThreadParticipant, id, threadParticipantRoomPrefix + id.String(), nil
 	}
 	if id, matched, err := parseRoomUUID(room, workloadRoomPrefix); matched {
 		if err != nil {
-			return roomKindWorkload, uuid.UUID{}, fmt.Errorf("workload: %w", err)
+			return roomKindWorkload, uuid.UUID{}, "", fmt.Errorf("workload: %w", err)
 		}
-		return roomKindWorkload, id, nil
+		return roomKindWorkload, id, workloadRoomPrefix + id.String(), nil
 	}
-	return roomKindOther, uuid.UUID{}, nil
+	if id, matched, err := parseRoomUUID(room, organizationRoomPrefix); matched {
+		if err != nil {
+			return roomKindOrganization, uuid.UUID{}, "", fmt.Errorf("organization: %w", err)
+		}
+		return roomKindOrganization, id, organizationRoomPrefix + id.String(), nil
+	}
+	return roomKindOther, uuid.UUID{}, "", nil
 }
 
 func parseRoomUUID(room string, prefix string) (uuid.UUID, bool, error) {

--- a/internal/server/rooms.go
+++ b/internal/server/rooms.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
+)
+
+const (
+	threadParticipantRoomPrefix = "thread_participant:"
+	workloadRoomPrefix          = "workload:"
+	organizationRoomPrefix      = "organization:"
+)
+
+type roomKind int
+
+const (
+	roomKindOther roomKind = iota
+	roomKindThreadParticipant
+	roomKindWorkload
+)
+
+type subscriptionRoom struct {
+	name string
+	kind roomKind
+	id   uuid.UUID
+}
+
+func parseSubscribeRooms(req *notificationsv1.SubscribeRequest) ([]subscriptionRoom, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request required")
+	}
+	rooms := req.GetRooms()
+	if len(rooms) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "rooms required")
+	}
+	seen := make(map[string]struct{}, len(rooms))
+	parsed := make([]subscriptionRoom, 0, len(rooms))
+	for i, room := range rooms {
+		trimmed := strings.TrimSpace(room)
+		if trimmed == "" {
+			return nil, status.Errorf(codes.InvalidArgument, "room %d is empty", i)
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		kind, id, err := classifyRoom(trimmed)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "room %d: %v", i, err)
+		}
+		parsed = append(parsed, subscriptionRoom{name: trimmed, kind: kind, id: id})
+	}
+	if len(parsed) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "rooms required")
+	}
+	return parsed, nil
+}
+
+func roomNames(rooms []subscriptionRoom) []string {
+	if len(rooms) == 0 {
+		return nil
+	}
+	values := make([]string, len(rooms))
+	for i, room := range rooms {
+		values[i] = room.name
+	}
+	return values
+}
+
+func classifyRoom(room string) (roomKind, uuid.UUID, error) {
+	if id, matched, err := parseRoomUUID(room, threadParticipantRoomPrefix); matched {
+		if err != nil {
+			return roomKindThreadParticipant, uuid.UUID{}, fmt.Errorf("thread_participant: %w", err)
+		}
+		return roomKindThreadParticipant, id, nil
+	}
+	if id, matched, err := parseRoomUUID(room, workloadRoomPrefix); matched {
+		if err != nil {
+			return roomKindWorkload, uuid.UUID{}, fmt.Errorf("workload: %w", err)
+		}
+		return roomKindWorkload, id, nil
+	}
+	return roomKindOther, uuid.UUID{}, nil
+}
+
+func parseRoomUUID(room string, prefix string) (uuid.UUID, bool, error) {
+	if !strings.HasPrefix(room, prefix) {
+		return uuid.UUID{}, false, nil
+	}
+	id, err := parseUUID(strings.TrimPrefix(room, prefix))
+	if err != nil {
+		return uuid.UUID{}, true, err
+	}
+	return id, true, nil
+}
+
+func parseUUID(value string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return uuid.UUID{}, fmt.Errorf("value is empty")
+	}
+	parsed, err := uuid.Parse(trimmed)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return parsed, nil
+}
+
+type WorkloadOrgResolver interface {
+	OrgIDForWorkload(workloadID uuid.UUID) (uuid.UUID, bool)
+}
+
+type WorkloadOrgRecorder interface {
+	RecordEnvelope(envelope *notificationsv1.NotificationEnvelope)
+}
+
+type WorkloadOrgIndex struct {
+	mu         sync.RWMutex
+	byWorkload map[uuid.UUID]uuid.UUID
+}
+
+func NewWorkloadOrgIndex() *WorkloadOrgIndex {
+	return &WorkloadOrgIndex{byWorkload: make(map[uuid.UUID]uuid.UUID)}
+}
+
+func (w *WorkloadOrgIndex) RecordEnvelope(envelope *notificationsv1.NotificationEnvelope) {
+	if envelope == nil {
+		return
+	}
+	rooms := envelope.GetRooms()
+	if len(rooms) == 0 {
+		return
+	}
+	var (
+		workloadID    uuid.UUID
+		orgID         uuid.UUID
+		foundWorkload bool
+		foundOrg      bool
+	)
+	for _, room := range rooms {
+		if id, matched, err := parseRoomUUID(room, workloadRoomPrefix); matched && err == nil {
+			workloadID = id
+			foundWorkload = true
+		}
+		if id, matched, err := parseRoomUUID(room, organizationRoomPrefix); matched && err == nil {
+			orgID = id
+			foundOrg = true
+		}
+	}
+	if !foundWorkload || !foundOrg {
+		return
+	}
+	w.mu.Lock()
+	w.byWorkload[workloadID] = orgID
+	w.mu.Unlock()
+}
+
+func (w *WorkloadOrgIndex) OrgIDForWorkload(workloadID uuid.UUID) (uuid.UUID, bool) {
+	w.mu.RLock()
+	orgID, ok := w.byWorkload[workloadID]
+	w.mu.RUnlock()
+	return orgID, ok
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
 )
 
@@ -22,7 +23,7 @@ type Publisher interface {
 // SubscriptionHub captures the subset of stream.Hub behaviour needed by the
 // server to register streaming clients.
 type SubscriptionHub interface {
-	Subscribe() (<-chan *notificationsv1.NotificationEnvelope, func())
+	Subscribe(rooms []string) (<-chan *notificationsv1.NotificationEnvelope, func())
 }
 
 // Clock produces the current time. Allows determinism in tests.
@@ -52,15 +53,39 @@ func WithIDGenerator(generator IDGenerator) Option {
 	}
 }
 
+// WithAuthorizationClient injects the Authorization service client.
+func WithAuthorizationClient(client authorizationv1.AuthorizationServiceClient) Option {
+	return func(s *Server) {
+		s.authorizationClient = client
+	}
+}
+
+// WithWorkloadOrgResolver injects a resolver for workload organization lookups.
+func WithWorkloadOrgResolver(resolver WorkloadOrgResolver) Option {
+	return func(s *Server) {
+		s.workloadOrgResolver = resolver
+	}
+}
+
+// WithWorkloadOrgRecorder injects a recorder for workload organization mappings.
+func WithWorkloadOrgRecorder(recorder WorkloadOrgRecorder) Option {
+	return func(s *Server) {
+		s.workloadOrgRecorder = recorder
+	}
+}
+
 // Server implements the NotificationsService gRPC handlers.
 type Server struct {
 	notificationsv1.UnimplementedNotificationsServiceServer
 
-	logger      *zap.Logger
-	publisher   Publisher
-	hub         SubscriptionHub
-	clock       Clock
-	idGenerator IDGenerator
+	logger              *zap.Logger
+	publisher           Publisher
+	hub                 SubscriptionHub
+	clock               Clock
+	idGenerator         IDGenerator
+	authorizationClient authorizationv1.AuthorizationServiceClient
+	workloadOrgResolver WorkloadOrgResolver
+	workloadOrgRecorder WorkloadOrgRecorder
 }
 
 // New constructs a Server with the provided dependencies.
@@ -101,6 +126,9 @@ func (s *Server) Publish(ctx context.Context, req *notificationsv1.PublishReques
 		s.logger.Error("publish failed", zap.Error(err))
 		return nil, status.Errorf(codes.Internal, "publish failed")
 	}
+	if s.workloadOrgRecorder != nil {
+		s.workloadOrgRecorder.RecordEnvelope(envelope)
+	}
 
 	return &notificationsv1.PublishResponse{Id: envelope.Id, Ts: envelope.Ts}, nil
 }
@@ -108,10 +136,25 @@ func (s *Server) Publish(ctx context.Context, req *notificationsv1.PublishReques
 // Subscribe streams live notifications to the caller until the context is
 // cancelled or the subscription is otherwise terminated.
 func (s *Server) Subscribe(req *notificationsv1.SubscribeRequest, stream notificationsv1.NotificationsService_SubscribeServer) error {
-	ch, cancel := s.hub.Subscribe()
-	defer cancel()
+	rooms, err := parseSubscribeRooms(req)
+	if err != nil {
+		return err
+	}
 
 	ctx := stream.Context()
+	callerID, hasIdentity, err := identityFromMetadata(ctx)
+	if err != nil {
+		return status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
+	if hasIdentity {
+		if err := s.authorizeSubscribe(ctx, callerID, rooms); err != nil {
+			return err
+		}
+	}
+
+	ch, cancel := s.hub.Subscribe(roomNames(rooms))
+	defer cancel()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -12,18 +13,21 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
 	"github.com/agynio/notifications/internal/server"
 	"github.com/agynio/notifications/internal/stream"
 )
 
 const bufSize = 1024 * 1024
+const identityMetadataKey = "x-identity-id"
 
 func TestPublish(t *testing.T) {
 	t.Parallel()
@@ -115,7 +119,7 @@ func TestSubscribe(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{})
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{"room"}})
 	if err != nil {
 		t.Fatalf("Subscribe returned error: %v", err)
 	}
@@ -154,7 +158,7 @@ func TestSubscribeContextCanceled(t *testing.T) {
 	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{})
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{"room"}})
 	if err != nil {
 		t.Fatalf("Subscribe returned error: %v", err)
 	}
@@ -173,6 +177,161 @@ func TestSubscribeContextCanceled(t *testing.T) {
 	}
 }
 
+func TestSubscribeThreadParticipantAuthorization(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(4, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	callerID := uuid.New()
+	room := fmt.Sprintf("thread_participant:%s", callerID)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, callerID.String())
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	envelope := &notificationsv1.NotificationEnvelope{
+		Id:     uuid.NewString(),
+		Ts:     timestamppb.Now(),
+		Event:  "evt",
+		Source: "src",
+		Rooms:  []string{room},
+		Payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"value": structpb.NewNumberValue(1),
+		}},
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		hub.Broadcast(envelope)
+	}()
+
+	msg, err := streamClient.Recv()
+	if err != nil {
+		t.Fatalf("Recv returned error: %v", err)
+	}
+	if !proto.Equal(envelope, msg.GetEnvelope()) {
+		t.Fatalf("unexpected envelope: %+v", msg.GetEnvelope())
+	}
+
+	badCtx := metadata.AppendToOutgoingContext(context.Background(), identityMetadataKey, uuid.NewString())
+	badStream, err := client.Subscribe(badCtx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	_, err = badStream.Recv()
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", err)
+	}
+}
+
+func TestSubscribeWorkloadAuthorization(t *testing.T) {
+	t.Parallel()
+
+	workloadID := uuid.New()
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	room := fmt.Sprintf("workload:%s", workloadID)
+	store := server.NewWorkloadOrgIndex()
+	store.RecordEnvelope(&notificationsv1.NotificationEnvelope{Rooms: []string{
+		fmt.Sprintf("organization:%s", organizationID),
+		room,
+	}})
+
+	tests := []struct {
+		name       string
+		allowed    bool
+		expectCode codes.Code
+	}{
+		{name: "allowed", allowed: true, expectCode: codes.OK},
+		{name: "denied", allowed: false, expectCode: codes.PermissionDenied},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hub := stream.NewHub(2, zap.NewNop())
+			checkCh := make(chan *authorizationv1.CheckRequest, 1)
+			authClient := fakeAuthorizationClient{
+				check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+					checkCh <- req
+					return &authorizationv1.CheckResponse{Allowed: tc.allowed}, nil
+				},
+			}
+			client, cleanup := startTestServer(t, &publisherStub{}, hub,
+				server.WithAuthorizationClient(authClient),
+				server.WithWorkloadOrgResolver(store),
+				server.WithWorkloadOrgRecorder(store),
+			)
+			defer cleanup()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, callerID.String())
+			streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+			if err != nil {
+				t.Fatalf("Subscribe returned error: %v", err)
+			}
+
+			if tc.expectCode != codes.OK {
+				_, err := streamClient.Recv()
+				if status.Code(err) != tc.expectCode {
+					t.Fatalf("expected code %v, got %v", tc.expectCode, status.Code(err))
+				}
+				select {
+				case <-checkCh:
+				case <-time.After(time.Second):
+					t.Fatal("expected authorization check")
+				}
+				return
+			}
+
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				hub.Broadcast(&notificationsv1.NotificationEnvelope{Id: uuid.NewString(), Ts: timestamppb.Now(), Rooms: []string{room}})
+			}()
+
+			if _, err := streamClient.Recv(); err != nil {
+				t.Fatalf("Recv returned error: %v", err)
+			}
+
+			select {
+			case gotCheck := <-checkCh:
+				if gotCheck.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+					t.Fatalf("unexpected object: %s", gotCheck.GetTupleKey().GetObject())
+				}
+			case <-time.After(time.Second):
+				t.Fatal("expected authorization check")
+			}
+		})
+	}
+}
+
+func TestSubscribeInternalBypassesAuthorization(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{fmt.Sprintf("workload:%s", uuid.NewString())}})
+	if err != nil {
+		cancel()
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	cancel()
+	_, err = streamClient.Recv()
+	if status.Code(err) != codes.Canceled {
+		t.Fatalf("expected canceled code, got %v", status.Code(err))
+	}
+}
+
 type publisherStub struct {
 	envelope *notificationsv1.NotificationEnvelope
 	err      error
@@ -186,9 +345,40 @@ func (p *publisherStub) Publish(ctx context.Context, envelope *notificationsv1.N
 	return nil
 }
 
+type fakeAuthorizationClient struct {
+	check func(context.Context, *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error)
+}
+
+func (f fakeAuthorizationClient) Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	if f.check == nil {
+		return &authorizationv1.CheckResponse{}, nil
+	}
+	return f.check(ctx, req)
+}
+
+func (f fakeAuthorizationClient) BatchCheck(ctx context.Context, req *authorizationv1.BatchCheckRequest, opts ...grpc.CallOption) (*authorizationv1.BatchCheckResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) Write(ctx context.Context, req *authorizationv1.WriteRequest, opts ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) Read(ctx context.Context, req *authorizationv1.ReadRequest, opts ...grpc.CallOption) (*authorizationv1.ReadResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) ListObjects(ctx context.Context, req *authorizationv1.ListObjectsRequest, opts ...grpc.CallOption) (*authorizationv1.ListObjectsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f fakeAuthorizationClient) ListUsers(ctx context.Context, req *authorizationv1.ListUsersRequest, opts ...grpc.CallOption) (*authorizationv1.ListUsersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 type noopHub struct{}
 
-func (n *noopHub) Subscribe() (<-chan *notificationsv1.NotificationEnvelope, func()) {
+func (n *noopHub) Subscribe(rooms []string) (<-chan *notificationsv1.NotificationEnvelope, func()) {
 	ch := make(chan *notificationsv1.NotificationEnvelope)
 	return ch, func() { close(ch) }
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -150,6 +150,49 @@ func TestSubscribe(t *testing.T) {
 	}
 }
 
+func TestSubscribeCanonicalizesRooms(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(4, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	workloadID := uuid.New()
+	requestRoom := fmt.Sprintf("workload: %s", workloadID)
+	canonicalRoom := fmt.Sprintf("workload:%s", workloadID)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{requestRoom}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	envelope := &notificationsv1.NotificationEnvelope{
+		Id:     uuid.NewString(),
+		Ts:     timestamppb.Now(),
+		Event:  "evt",
+		Source: "src",
+		Rooms:  []string{canonicalRoom},
+		Payload: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"value": structpb.NewNumberValue(1),
+		}},
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		hub.Broadcast(envelope)
+	}()
+
+	msg, err := streamClient.Recv()
+	if err != nil {
+		t.Fatalf("Recv returned error: %v", err)
+	}
+	if !proto.Equal(envelope, msg.GetEnvelope()) {
+		t.Fatalf("unexpected envelope: %+v", msg.GetEnvelope())
+	}
+}
+
 func TestSubscribeContextCanceled(t *testing.T) {
 	t.Parallel()
 
@@ -308,6 +351,100 @@ func TestSubscribeWorkloadAuthorization(t *testing.T) {
 				t.Fatal("expected authorization check")
 			}
 		})
+	}
+}
+
+func TestSubscribeOrganizationAuthorization(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.New()
+	callerID := uuid.New()
+	room := fmt.Sprintf("organization:%s", organizationID)
+
+	tests := []struct {
+		name       string
+		allowed    bool
+		expectCode codes.Code
+	}{
+		{name: "allowed", allowed: true, expectCode: codes.OK},
+		{name: "denied", allowed: false, expectCode: codes.PermissionDenied},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hub := stream.NewHub(2, zap.NewNop())
+			checkCh := make(chan *authorizationv1.CheckRequest, 1)
+			authClient := fakeAuthorizationClient{
+				check: func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+					checkCh <- req
+					return &authorizationv1.CheckResponse{Allowed: tc.allowed}, nil
+				},
+			}
+			client, cleanup := startTestServer(t, &publisherStub{}, hub,
+				server.WithAuthorizationClient(authClient),
+			)
+			defer cleanup()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, callerID.String())
+			streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+			if err != nil {
+				t.Fatalf("Subscribe returned error: %v", err)
+			}
+
+			if tc.expectCode != codes.OK {
+				_, err := streamClient.Recv()
+				if status.Code(err) != tc.expectCode {
+					t.Fatalf("expected code %v, got %v", tc.expectCode, status.Code(err))
+				}
+				select {
+				case <-checkCh:
+				case <-time.After(time.Second):
+					t.Fatal("expected authorization check")
+				}
+				return
+			}
+
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				hub.Broadcast(&notificationsv1.NotificationEnvelope{Id: uuid.NewString(), Ts: timestamppb.Now(), Rooms: []string{room}})
+			}()
+
+			if _, err := streamClient.Recv(); err != nil {
+				t.Fatalf("Recv returned error: %v", err)
+			}
+
+			select {
+			case gotCheck := <-checkCh:
+				if gotCheck.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+					t.Fatalf("unexpected object: %s", gotCheck.GetTupleKey().GetObject())
+				}
+			case <-time.After(time.Second):
+				t.Fatal("expected authorization check")
+			}
+		})
+	}
+}
+
+func TestSubscribeUnknownRoomAuthorization(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = metadata.AppendToOutgoingContext(ctx, identityMetadataKey, uuid.NewString())
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{"agent:unknown"}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	_, err = streamClient.Recv()
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", status.Code(err))
 	}
 }
 

--- a/internal/stream/hub.go
+++ b/internal/stream/hub.go
@@ -38,8 +38,8 @@ func NewHub(bufferSize int, logger *zap.Logger) *Hub {
 	}
 }
 
-// Broadcast delivers the envelope to all subscribers. Slow subscribers are
-// dropped and their channels are closed.
+// Broadcast delivers the envelope to subscribers of the envelope rooms. Slow
+// subscribers are dropped and their channels are closed.
 func (h *Hub) Broadcast(envelope *notificationsv1.NotificationEnvelope) {
 	if envelope == nil {
 		return

--- a/internal/stream/hub.go
+++ b/internal/stream/hub.go
@@ -9,9 +9,10 @@ import (
 )
 
 type subscriber struct {
-	id  int
-	ch  chan *notificationsv1.NotificationEnvelope
-	end bool
+	id    int
+	ch    chan *notificationsv1.NotificationEnvelope
+	end   bool
+	rooms map[string]struct{}
 }
 
 // Hub fan-outs envelopes to registered subscribers with bounded buffers.
@@ -21,6 +22,7 @@ type Hub struct {
 	bufferSize int
 	nextID     int
 	subs       map[int]*subscriber
+	roomSubs   map[string]map[int]*subscriber
 }
 
 // NewHub creates a hub for broadcasting notifications to consumers.
@@ -32,6 +34,7 @@ func NewHub(bufferSize int, logger *zap.Logger) *Hub {
 		logger:     logger,
 		bufferSize: bufferSize,
 		subs:       make(map[int]*subscriber),
+		roomSubs:   make(map[string]map[int]*subscriber),
 	}
 }
 
@@ -45,21 +48,29 @@ func (h *Hub) Broadcast(envelope *notificationsv1.NotificationEnvelope) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	for id, sub := range h.subs {
-		if sub.end {
-			continue
-		}
-		select {
-		case sub.ch <- envelope:
-		default:
-			h.dropSubscriberLocked(id, sub, "slow consumer")
+	delivered := make(map[int]struct{})
+	for _, room := range envelope.GetRooms() {
+		subscribers := h.roomSubs[room]
+		for id, sub := range subscribers {
+			if sub.end {
+				continue
+			}
+			if _, ok := delivered[id]; ok {
+				continue
+			}
+			select {
+			case sub.ch <- envelope:
+				delivered[id] = struct{}{}
+			default:
+				h.dropSubscriberLocked(id, sub, "slow consumer")
+			}
 		}
 	}
 }
 
 // Subscribe registers a new consumer and returns a read-only channel alongside
 // a closure to remove the consumer.
-func (h *Hub) Subscribe() (<-chan *notificationsv1.NotificationEnvelope, func()) {
+func (h *Hub) Subscribe(rooms []string) (<-chan *notificationsv1.NotificationEnvelope, func()) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -67,7 +78,18 @@ func (h *Hub) Subscribe() (<-chan *notificationsv1.NotificationEnvelope, func())
 	h.nextID++
 
 	ch := make(chan *notificationsv1.NotificationEnvelope, h.bufferSize)
-	h.subs[id] = &subscriber{id: id, ch: ch}
+	sub := &subscriber{id: id, ch: ch, rooms: make(map[string]struct{})}
+	h.subs[id] = sub
+	for _, room := range rooms {
+		if _, ok := sub.rooms[room]; ok {
+			continue
+		}
+		sub.rooms[room] = struct{}{}
+		if h.roomSubs[room] == nil {
+			h.roomSubs[room] = make(map[int]*subscriber)
+		}
+		h.roomSubs[room][id] = sub
+	}
 
 	return ch, func() {
 		h.mu.Lock()
@@ -84,6 +106,14 @@ func (h *Hub) dropSubscriberLocked(id int, sub *subscriber, reason string) {
 	}
 	sub.end = true
 	close(sub.ch)
+	for room := range sub.rooms {
+		if subscribers, ok := h.roomSubs[room]; ok {
+			delete(subscribers, id)
+			if len(subscribers) == 0 {
+				delete(h.roomSubs, room)
+			}
+		}
+	}
 	delete(h.subs, id)
 	if h.logger != nil {
 		h.logger.Warn("dropping subscriber", zap.Int("subscriber_id", id), zap.String("reason", reason))

--- a/internal/stream/hub_test.go
+++ b/internal/stream/hub_test.go
@@ -17,13 +17,13 @@ func TestHubBroadcastDeliversToSubscribers(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	hub := NewHub(2, logger)
 
-	ch1, cancel1 := hub.Subscribe()
+	ch1, cancel1 := hub.Subscribe([]string{"room-a"})
 	defer cancel1()
 
-	ch2, cancel2 := hub.Subscribe()
+	ch2, cancel2 := hub.Subscribe([]string{"room-a"})
 	defer cancel2()
 
-	envelope := &notificationsv1.NotificationEnvelope{Id: "id", Ts: timestamppb.Now()}
+	envelope := &notificationsv1.NotificationEnvelope{Id: "id", Ts: timestamppb.Now(), Rooms: []string{"room-a"}}
 
 	hub.Broadcast(envelope)
 
@@ -46,18 +46,50 @@ func TestHubBroadcastDeliversToSubscribers(t *testing.T) {
 	}
 }
 
+func TestHubBroadcastFiltersRooms(t *testing.T) {
+	t.Parallel()
+
+	logger := zap.NewNop()
+	hub := NewHub(1, logger)
+
+	chA, cancelA := hub.Subscribe([]string{"room-a"})
+	defer cancelA()
+
+	chB, cancelB := hub.Subscribe([]string{"room-b"})
+	defer cancelB()
+
+	envelope := &notificationsv1.NotificationEnvelope{Id: "id", Ts: timestamppb.Now(), Rooms: []string{"room-a"}}
+
+	hub.Broadcast(envelope)
+
+	select {
+	case msg := <-chA:
+		if msg.GetId() != envelope.GetId() {
+			t.Fatalf("unexpected id: got %s want %s", msg.GetId(), envelope.GetId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for room-a subscriber")
+	}
+
+	select {
+	case <-chB:
+		t.Fatal("room-b subscriber should not receive room-a envelope")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestHubDropsSlowSubscriber(t *testing.T) {
 	t.Parallel()
 
 	logger := zap.NewNop()
 	hub := NewHub(1, logger)
 
-	chSlow, _ := hub.Subscribe()
-	chFast, cancelFast := hub.Subscribe()
+	chSlow, _ := hub.Subscribe([]string{"room-a"})
+	chFast, cancelFast := hub.Subscribe([]string{"room-a"})
 	defer cancelFast()
 
-	envelope1 := &notificationsv1.NotificationEnvelope{Id: "event-1", Ts: timestamppb.Now()}
-	envelope2 := &notificationsv1.NotificationEnvelope{Id: "event-2", Ts: timestamppb.Now()}
+	envelope1 := &notificationsv1.NotificationEnvelope{Id: "event-1", Ts: timestamppb.Now(), Rooms: []string{"room-a"}}
+	envelope2 := &notificationsv1.NotificationEnvelope{Id: "event-2", Ts: timestamppb.Now(), Rooms: []string{"room-a"}}
 
 	hub.Broadcast(envelope1)
 	hub.Broadcast(envelope2)


### PR DESCRIPTION
## Summary
- scope hub fanout to subscription rooms and validate Subscribe rooms
- add workload org index + external Subscribe authorization checks for thread_participant/workload rooms
- wire authorization client/config and add coverage for room scoping/auth flows

## Testing
- buf generate buf.build/agynio/api --template ./buf.gen.yaml
- go vet ./...
- go test ./...
- go build ./...

## Issue
- https://github.com/agynio/architecture/issues/142