### PR TITLE
fix(buf): skip otel go package rewrite

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,6 +2,9 @@ version: v2
 
 managed:
   enabled: true
+  disable:
+    - file_option: go_package_prefix
+      module: buf.build/opentelemetry/opentelemetry
   override:
     - file_option: go_package_prefix
       value: github.com/agynio/notifications/internal/.gen


### PR DESCRIPTION
## Summary
- disable managed go_package_prefix rewrites for OpenTelemetry protos so imports use the upstream module

## Testing
- go test ./...
- go vet ./...
- go build ./...

Refs agynio/bootstrap#459