### PR TITLE
fix(notifications): allow internal subscribers

### DIFF
--- a/cmd/notifications/main.go
+++ b/cmd/notifications/main.go
@@ -142,6 +142,7 @@ func run() error {
 			server.WithWorkloadOrgRecorder(workloadOrgIndex),
 			server.WithTraceOrgResolver(traceOrgIndex),
 			server.WithTraceOrgRecorder(traceOrgIndex),
+			server.WithInternalSubscribeToken(cfg.InternalSubscribeToken),
 		),
 	)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,17 +22,18 @@ const (
 
 // Config captures runtime configuration derived from the environment.
 type Config struct {
-	GRPCAddr          string
-	RedisAddr         string
-	RedisPassword     string
-	RedisDB           int
-	RedisChannel      string
-	StreamBufferSize  int
-	LogLevel          string
-	AuthorizationAddr string
-	RunnersAddr       string
-	AgentsAddr        string
-	TracingAddr       string
+	GRPCAddr               string
+	RedisAddr              string
+	RedisPassword          string
+	RedisDB                int
+	RedisChannel           string
+	StreamBufferSize       int
+	LogLevel               string
+	AuthorizationAddr      string
+	RunnersAddr            string
+	AgentsAddr             string
+	TracingAddr            string
+	InternalSubscribeToken string
 }
 
 // Load reads configuration from environment variables, applying defaults when
@@ -60,6 +61,7 @@ func Load() (Config, error) {
 	cfg.RunnersAddr = readEnv("RUNNERS_ADDR", defaultRunnersServiceAddr)
 	cfg.AgentsAddr = readEnv("AGENTS_ADDR", defaultAgentsServiceAddr)
 	cfg.TracingAddr = readEnv("TRACING_ADDR", defaultTracingServiceAddr)
+	cfg.InternalSubscribeToken = readEnv("INTERNAL_SUBSCRIBE_TOKEN", "")
 
 	bufferStr := readEnv("STREAM_BUFFER_SIZE", "")
 	if bufferStr == "" {

--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -61,7 +61,7 @@ func (s *Server) authorizeSubscribe(ctx context.Context, identityID uuid.UUID, r
 			if err != nil {
 				return err
 			}
-			allowed, err := s.viewWorkloadsAllowed(ctx, identityID, organizationID, viewWorkloadsCache)
+			allowed, err := s.memberAllowed(ctx, identityID, organizationID, memberCache)
 			if err != nil {
 				return err
 			}

--- a/internal/server/authz.go
+++ b/internal/server/authz.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	identityMetadata                  = "x-identity-id"
+	serviceTokenMetadata              = "x-service-token"
 	organizationMemberRelation        = "member"
 	organizationViewWorkloadsRelation = "can_view_workloads"
 	identityObjectPrefix              = "identity:"
@@ -44,6 +45,44 @@ func identityFromMetadata(ctx context.Context) (uuid.UUID, bool, error) {
 		return uuid.UUID{}, true, err
 	}
 	return identityID, true, nil
+}
+
+func serviceTokenFromMetadata(ctx context.Context) (string, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false, nil
+	}
+	values := md.Get(serviceTokenMetadata)
+	if len(values) == 0 {
+		return "", false, nil
+	}
+	if len(values) != 1 {
+		return "", true, fmt.Errorf("expected single %s", serviceTokenMetadata)
+	}
+	trimmed := strings.TrimSpace(values[0])
+	if trimmed == "" {
+		return "", true, fmt.Errorf("%s is empty", serviceTokenMetadata)
+	}
+	return trimmed, true, nil
+}
+
+func (s *Server) authorizeInternalSubscribe(ctx context.Context, rooms []subscriptionRoom) error {
+	token, hasToken, err := serviceTokenFromMetadata(ctx)
+	if err != nil {
+		return status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
+	if !hasToken || s.internalSubscribeToken == "" || token != s.internalSubscribeToken {
+		return status.Error(codes.Unauthenticated, "unauthenticated")
+	}
+	for _, room := range rooms {
+		switch room.kind {
+		case roomKindThreadParticipant, roomKindAgent:
+			continue
+		default:
+			return status.Error(codes.PermissionDenied, "permission denied")
+		}
+	}
+	return nil
 }
 
 func (s *Server) authorizeSubscribe(ctx context.Context, identityID uuid.UUID, rooms []subscriptionRoom) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,17 +155,25 @@ func (s *Server) Subscribe(req *notificationsv1.SubscribeRequest, stream notific
 	if err != nil {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
 	}
-	if !hasIdentity {
-		return status.Error(codes.Unauthenticated, "unauthenticated")
-	}
-
 	rooms, err := parseSubscribeRooms(req)
 	if err != nil {
 		return err
 	}
 
-	if err := s.authorizeSubscribe(ctx, callerID, rooms); err != nil {
-		return err
+	// Reject unknown room kinds for both internal and external subscribers.
+	for _, room := range rooms {
+		if room.kind == roomKindOther {
+			return status.Error(codes.PermissionDenied, "permission denied")
+		}
+	}
+
+	// External subscribers (via the Gateway) carry x-identity-id metadata and are
+	// authorized per room. Internal subscribers may omit identity metadata and are
+	// treated as trusted.
+	if hasIdentity {
+		if err := s.authorizeSubscribe(ctx, callerID, rooms); err != nil {
+			return err
+		}
 	}
 
 	ch, cancel := s.hub.Subscribe(roomNames(rooms))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,23 +80,31 @@ func WithTraceOrgRecorder(recorder TraceOrgRecorder) Option {
 	}
 }
 
+// WithInternalSubscribeToken configures the service token required for internal subscriptions.
+func WithInternalSubscribeToken(token string) Option {
+	return func(s *Server) {
+		s.internalSubscribeToken = strings.TrimSpace(token)
+	}
+}
+
 // Server implements the NotificationsService gRPC handlers.
 type Server struct {
 	notificationsv1.UnimplementedNotificationsServiceServer
 
-	logger              *zap.Logger
-	publisher           Publisher
-	hub                 SubscriptionHub
-	clock               Clock
-	idGenerator         IDGenerator
-	authorizationClient AuthorizationClient
-	runnersClient       RunnersClient
-	agentsClient        AgentsClient
-	tracingClient       TracingClient
-	workloadOrgResolver WorkloadOrgResolver
-	workloadOrgRecorder WorkloadOrgRecorder
-	traceOrgResolver    TraceOrgResolver
-	traceOrgRecorder    TraceOrgRecorder
+	logger                 *zap.Logger
+	publisher              Publisher
+	hub                    SubscriptionHub
+	clock                  Clock
+	idGenerator            IDGenerator
+	authorizationClient    AuthorizationClient
+	runnersClient          RunnersClient
+	agentsClient           AgentsClient
+	tracingClient          TracingClient
+	workloadOrgResolver    WorkloadOrgResolver
+	workloadOrgRecorder    WorkloadOrgRecorder
+	traceOrgResolver       TraceOrgResolver
+	traceOrgRecorder       TraceOrgRecorder
+	internalSubscribeToken string
 }
 
 // New constructs a Server with the provided dependencies.
@@ -168,10 +176,14 @@ func (s *Server) Subscribe(req *notificationsv1.SubscribeRequest, stream notific
 	}
 
 	// External subscribers (via the Gateway) carry x-identity-id metadata and are
-	// authorized per room. Internal subscribers may omit identity metadata and are
-	// treated as trusted.
+	// authorized per room. Internal subscribers must present a service token and
+	// are limited to an allowlist of room kinds.
 	if hasIdentity {
 		if err := s.authorizeSubscribe(ctx, callerID, rooms); err != nil {
+			return err
+		}
+	} else {
+		if err := s.authorizeInternalSubscribe(ctx, rooms); err != nil {
 			return err
 		}
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	bufSize             = 1024 * 1024
-	identityMetadataKey = "x-identity-id"
+	bufSize                 = 1024 * 1024
+	identityMetadataKey     = "x-identity-id"
+	serviceTokenMetadataKey = "x-service-token"
 )
 
 func TestPublish(t *testing.T) {
@@ -832,17 +833,61 @@ func TestSubscribeUnknownRoomAuthorization(t *testing.T) {
 	}
 }
 
-func TestSubscribeAllowsInternalWithoutIdentity(t *testing.T) {
+func TestSubscribeRejectsInternalWithoutToken(t *testing.T) {
 	t.Parallel()
 
 	hub := stream.NewHub(2, zap.NewNop())
-	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	client, cleanup := startTestServer(t, &publisherStub{}, hub, server.WithInternalSubscribeToken("internal-token"))
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	room := fmt.Sprintf("thread_participant:%s", uuid.NewString())
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	_, err = streamClient.Recv()
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated error, got %v", status.Code(err))
+	}
+}
+
+func TestSubscribeRejectsInternalRoomKind(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub, server.WithInternalSubscribeToken("internal-token"))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(serviceTokenMetadataKey, "internal-token"))
+
 	room := fmt.Sprintf("workload:%s", uuid.NewString())
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	_, err = streamClient.Recv()
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied error, got %v", status.Code(err))
+	}
+}
+
+func TestSubscribeAllowsInternalWithToken(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub, server.WithInternalSubscribeToken("internal-token"))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(serviceTokenMetadataKey, "internal-token"))
+
+	room := fmt.Sprintf("thread_participant:%s", uuid.NewString())
 	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
 	if err != nil {
 		t.Fatalf("Subscribe returned error: %v", err)
@@ -949,15 +994,19 @@ func startTestServer(t *testing.T, publisher server.Publisher, hub server.Subscr
 		return listener.Dial()
 	}
 
-	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough:///bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial bufnet: %v", err)
 	}
 
 	client := notificationsv1.NewNotificationsServiceClient(conn)
 	cleanup := func() {
-		conn.Close()
-		listener.Close()
+		if err := conn.Close(); err != nil {
+			t.Errorf("close connection: %v", err)
+		}
+		if err := listener.Close(); err != nil {
+			t.Errorf("close listener: %v", err)
+		}
 		grpcServer.Stop()
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -513,8 +513,8 @@ func TestSubscribeWorkloadAuthorization(t *testing.T) {
 			if len(authClient.requests) != 1 {
 				t.Fatalf("expected 1 authorization request, got %d", len(authClient.requests))
 			}
-			if authClient.requests[0].GetTupleKey().GetRelation() != "can_view_workloads" {
-				t.Fatalf("expected can_view_workloads relation, got %s", authClient.requests[0].GetTupleKey().GetRelation())
+			if authClient.requests[0].GetTupleKey().GetRelation() != "member" {
+				t.Fatalf("expected member relation, got %s", authClient.requests[0].GetTupleKey().GetRelation())
 			}
 			if authClient.requests[0].GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
 				t.Fatalf("unexpected object: %s", authClient.requests[0].GetTupleKey().GetObject())
@@ -832,7 +832,7 @@ func TestSubscribeUnknownRoomAuthorization(t *testing.T) {
 	}
 }
 
-func TestSubscribeRequiresIdentity(t *testing.T) {
+func TestSubscribeAllowsInternalWithoutIdentity(t *testing.T) {
 	t.Parallel()
 
 	hub := stream.NewHub(2, zap.NewNop())
@@ -841,12 +841,20 @@ func TestSubscribeRequiresIdentity(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{fmt.Sprintf("workload:%s", uuid.NewString())}})
-	if err == nil {
-		_, err = streamClient.Recv()
+
+	room := fmt.Sprintf("workload:%s", uuid.NewString())
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
 	}
-	if status.Code(err) != codes.Unauthenticated {
-		t.Fatalf("expected unauthenticated code, got %v", status.Code(err))
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		hub.Broadcast(&notificationsv1.NotificationEnvelope{Id: uuid.NewString(), Ts: timestamppb.Now(), Rooms: []string{room}})
+	}()
+
+	if _, err := streamClient.Recv(); err != nil {
+		t.Fatalf("Recv returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes two issues seen post-rollout:

1) Internal services (e.g. orchestrator) subscribing without `x-identity-id` were rejected with Unauthenticated, causing noisy retry/spam.
2) `workload:{id}` room subscriptions were overly strict.

Changes:
- If `x-identity-id` header is missing, treat subscriber as internal/trusted and skip per-room authz checks.
  - Still validates room kinds (unknown kinds rejected for all subscribers).
- External subscribers (with identity) remain authorized per room.
- `workload:{id}` / `agent:{id}` rooms now require org `member`.

Tests updated to cover the internal subscriber path.