### PR TITLE
feat: authorize instance inbox rooms

### DIFF
--- a/internal/server/rooms.go
+++ b/internal/server/rooms.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	threadParticipantRoomPrefix = "thread_participant:"
+	instanceInboxRoomPrefix     = "instance_inbox:"
 	workloadRoomPrefix          = "workload:"
 	organizationRoomPrefix      = "organization:"
 	agentRoomPrefix             = "agent:"
@@ -26,6 +27,7 @@ type roomKind int
 const (
 	roomKindOther roomKind = iota
 	roomKindThreadParticipant
+	roomKindInstanceInbox
 	roomKindWorkload
 	roomKindOrganization
 	roomKindAgent
@@ -99,6 +101,20 @@ func classifyRoom(room string, callerID uuid.UUID) (roomKind, uuid.UUID, string,
 			return roomKindThreadParticipant, uuid.UUID{}, "", "", fmt.Errorf("thread_participant: %w", err)
 		}
 		return roomKindThreadParticipant, id, "", threadParticipantRoomPrefix + id.String(), nil
+	}
+	if strings.HasPrefix(room, instanceInboxRoomPrefix) {
+		raw := strings.TrimSpace(strings.TrimPrefix(room, instanceInboxRoomPrefix))
+		if raw == selfRoomIDSegment {
+			if callerID == uuid.Nil {
+				return roomKindInstanceInbox, uuid.UUID{}, "", "", fmt.Errorf("instance_inbox: caller identity is required for %q", selfRoomIDSegment)
+			}
+			return roomKindInstanceInbox, callerID, "", instanceInboxRoomPrefix + callerID.String(), nil
+		}
+		id, err := parseUUID(raw)
+		if err != nil {
+			return roomKindInstanceInbox, uuid.UUID{}, "", "", fmt.Errorf("instance_inbox: %w", err)
+		}
+		return roomKindInstanceInbox, id, "", instanceInboxRoomPrefix + id.String(), nil
 	}
 	if id, matched, err := parseRoomUUID(room, workloadRoomPrefix); matched {
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,6 +106,13 @@ func (s *Server) Publish(ctx context.Context, req *notificationsv1.PublishReques
 	return &notificationsv1.PublishResponse{Id: envelope.Id, Ts: envelope.Ts}, nil
 }
 
+type callerIdentity struct {
+	id           uuid.UUID
+	identityType string
+}
+
+const agentInstanceIdentityType = "agent_instance"
+
 func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -125,10 +132,39 @@ func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	return uuid.UUID{}, status.Error(codes.Unauthenticated, "identity not available")
 }
 
-func authorizeSubscribeRooms(callerID uuid.UUID, rooms []subscriptionRoom) error {
+func identityTypeFromContext(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	for _, value := range md.Get("x-identity-type") {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func callerIdentityFromContext(ctx context.Context) (callerIdentity, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return callerIdentity{}, err
+	}
+	return callerIdentity{id: identityID, identityType: identityTypeFromContext(ctx)}, nil
+}
+
+func authorizeSubscribeRooms(caller callerIdentity, rooms []subscriptionRoom) error {
 	for _, room := range rooms {
-		if room.kind == roomKindThreadParticipant && room.id != callerID {
-			return status.Error(codes.PermissionDenied, "permission denied")
+		switch room.kind {
+		case roomKindThreadParticipant:
+			if room.id != caller.id {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+		case roomKindInstanceInbox:
+			if room.id != caller.id || caller.identityType != agentInstanceIdentityType {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
 		}
 	}
 	return nil
@@ -138,15 +174,15 @@ func authorizeSubscribeRooms(callerID uuid.UUID, rooms []subscriptionRoom) error
 // cancelled or the subscription is otherwise terminated.
 func (s *Server) Subscribe(req *notificationsv1.SubscribeRequest, stream notificationsv1.NotificationsService_SubscribeServer) error {
 	ctx := stream.Context()
-	callerID, err := identityIDFromContext(ctx)
+	caller, err := callerIdentityFromContext(ctx)
 	if err != nil {
 		return err
 	}
-	rooms, err := parseSubscribeRooms(req, callerID)
+	rooms, err := parseSubscribeRooms(req, caller.id)
 	if err != nil {
 		return err
 	}
-	if err := authorizeSubscribeRooms(callerID, rooms); err != nil {
+	if err := authorizeSubscribeRooms(caller, rooms); err != nil {
 		return err
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -552,6 +552,133 @@ func TestSubscribeThreadParticipantSelfRoomDedupesWithExplicitRoom(t *testing.T)
 	}
 }
 
+func TestSubscribeInstanceInboxSelfRoom(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(4, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	callerID := uuid.New()
+	room := fmt.Sprintf("instance_inbox:%s", callerID)
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(callerID, "agent_instance"), time.Second)
+	defer cancel()
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{"instance_inbox:me"}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	envelope := &notificationsv1.NotificationEnvelope{Id: uuid.NewString(), Ts: timestamppb.Now(), Event: "evt", Source: "src", Rooms: []string{room}}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		hub.Broadcast(envelope)
+	}()
+
+	msg, err := streamClient.Recv()
+	if err != nil {
+		t.Fatalf("Recv returned error: %v", err)
+	}
+	if !proto.Equal(envelope, msg.GetEnvelope()) {
+		t.Fatalf("unexpected envelope: %+v", msg.GetEnvelope())
+	}
+}
+
+func TestSubscribeInstanceInboxSelfRoomDedupesWithExplicitRoom(t *testing.T) {
+	t.Parallel()
+
+	hub := &recordingHub{}
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	callerID := uuid.New()
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(callerID, "agent_instance"), time.Second)
+	defer cancel()
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{"instance_inbox:me", fmt.Sprintf("instance_inbox:%s", callerID)}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	_, err = streamClient.Recv()
+	if status.Code(err) != codes.Canceled && status.Code(err) != codes.DeadlineExceeded {
+		// The important assertion is below; allow the stream to terminate by context.
+	}
+	if len(hub.rooms) != 1 || hub.rooms[0] != fmt.Sprintf("instance_inbox:%s", callerID) {
+		t.Fatalf("unexpected subscribed rooms: %#v", hub.rooms)
+	}
+}
+
+func TestSubscribeInstanceInboxWrongIdentityDenied(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{})
+	defer cleanup()
+
+	ctx := authenticatedContextWithType(uuid.New(), "agent_instance")
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{fmt.Sprintf("instance_inbox:%s", uuid.New())}})
+	if err == nil {
+		_, err = streamClient.Recv()
+	}
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestSubscribeInstanceInboxConcreteRoomAllowsMatchingAgentInstance(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(4, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	callerID := uuid.New()
+	room := fmt.Sprintf("instance_inbox:%s", callerID)
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(callerID, "agent_instance"), time.Second)
+	defer cancel()
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	envelope := &notificationsv1.NotificationEnvelope{Id: uuid.NewString(), Ts: timestamppb.Now(), Event: "evt", Source: "src", Rooms: []string{room}}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		hub.Broadcast(envelope)
+	}()
+
+	msg, err := streamClient.Recv()
+	if err != nil {
+		t.Fatalf("Recv returned error: %v", err)
+	}
+	if !proto.Equal(envelope, msg.GetEnvelope()) {
+		t.Fatalf("unexpected envelope: %+v", msg.GetEnvelope())
+	}
+}
+
+func TestSubscribeInstanceInboxRequiresAgentInstanceIdentityType(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{})
+	defer cleanup()
+
+	for _, identityType := range []string{"", "user", "app", "agent"} {
+		identityType := identityType
+		for _, room := range []string{"instance_inbox:me", fmt.Sprintf("instance_inbox:%s", uuid.New())} {
+			room := room
+			t.Run(identityType+"/"+room, func(t *testing.T) {
+				ctx := authenticatedContextWithType(uuid.New(), identityType)
+				streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+				if err == nil {
+					_, err = streamClient.Recv()
+				}
+				if status.Code(err) != codes.PermissionDenied {
+					t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
+				}
+			})
+		}
+	}
+}
+
 func TestSubscribeThreadParticipantWrongIdentityDenied(t *testing.T) {
 	t.Parallel()
 
@@ -584,7 +711,15 @@ func TestSubscribeThreadParticipantSelfRequiresIdentity(t *testing.T) {
 }
 
 func authenticatedContext(identityID uuid.UUID) context.Context {
-	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	return authenticatedContextWithType(identityID, "")
+}
+
+func authenticatedContextWithType(identityID uuid.UUID, identityType string) context.Context {
+	pairs := []string{"x-identity-id", identityID.String()}
+	if identityType != "" {
+		pairs = append(pairs, "x-identity-type", identityType)
+	}
+	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs(pairs...))
 }
 
 type recordingHub struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -659,13 +659,14 @@ func TestSubscribeInstanceInboxRequiresAgentInstanceIdentityType(t *testing.T) {
 	t.Parallel()
 
 	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{})
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	for _, identityType := range []string{"", "user", "app", "agent"} {
 		identityType := identityType
 		for _, room := range []string{"instance_inbox:me", fmt.Sprintf("instance_inbox:%s", uuid.New())} {
 			room := room
 			t.Run(identityType+"/"+room, func(t *testing.T) {
+				t.Parallel()
 				ctx := authenticatedContextWithType(uuid.New(), identityType)
 				streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
 				if err == nil {


### PR DESCRIPTION
## Summary

- Add `instance_inbox:{id}` and `instance_inbox:me` room parsing/canonicalization.
- Enforce instance inbox subscription authorization: caller identity id must match the room id and `x-identity-type` must be `agent_instance`.
- Keep `thread_participant:{id}` authorization unchanged.
- Add tests covering self sentinel resolution, explicit concrete room subscription, dedupe, wrong identity id denial, and user/app/non-agent-instance denial.

## Validation

- `PATH=/root/go/bin:$PATH buf generate buf.build/agynio/api --template ./buf.gen.yaml` — passed.
- `go test -json ./...` — passed: 48 passed, 0 failed, 0 skipped.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed.
- `git diff --check` — passed with no whitespace errors.

## E2E

- `devspace run test:e2e` could not run because DevSpace 6 rejects the command name in this repo config: `commands.test:e2e has to match the following regex: ^(([a-z0-9][a-z0-9\-]*[a-z0-9])|([a-z0-9]))$`.
- `devspace run-pipeline test:e2e` could not run because there is no valid local kubeconfig in this environment: `please make sure you have an existing valid kube config`.

#161