### PR TITLE
fix(devspace): find the pod by name, not by release

### DIFF
--- a/cmd/notifications/main.go
+++ b/cmd/notifications/main.go
@@ -11,7 +11,10 @@ import (
 	"syscall"
 	"time"
 
+	agentsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
+	runnersv1 "github.com/agynio/notifications/internal/.gen/agynio/api/runners/v1"
 	"github.com/agynio/notifications/internal/config"
 	"github.com/agynio/notifications/internal/logging"
 	redisstream "github.com/agynio/notifications/internal/redis"
@@ -21,6 +24,7 @@ import (
 	redis "github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -96,11 +100,41 @@ func run() error {
 		}
 	}()
 
+	// Subscribe authorizes every room against the organization that owns the
+	// entity it reports on, so it needs the Authorization service and the two
+	// services that can name that organization.
+	authzConn, err := grpc.NewClient(cfg.AuthorizationAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		forwardCancel()
+		subscriber.Stop()
+		return fmt.Errorf("connect to authorization service: %w", err)
+	}
+	defer func() { _ = authzConn.Close() }()
+	runnersConn, err := grpc.NewClient(cfg.RunnersAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		forwardCancel()
+		subscriber.Stop()
+		return fmt.Errorf("connect to runners service: %w", err)
+	}
+	defer func() { _ = runnersConn.Close() }()
+	agentsConn, err := grpc.NewClient(cfg.AgentsAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		forwardCancel()
+		subscriber.Stop()
+		return fmt.Errorf("connect to agents service: %w", err)
+	}
+	defer func() { _ = agentsConn.Close() }()
+
 	grpcServer := grpc.NewServer()
 	notificationsv1.RegisterNotificationsServiceServer(
 		grpcServer,
 		server.New(publisher, hub, logger,
 			server.WithClock(func() time.Time { return time.Now().UTC() }),
+			server.WithAuthorization(
+				authorizationv1.NewAuthorizationServiceClient(authzConn),
+				runnersv1.NewRunnersServiceClient(runnersConn),
+				agentsv1.NewAgentsServiceClient(agentsConn),
+			),
 		),
 	)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -173,8 +173,6 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"
 
   e2e-runner:
     namespace: ${NOTIFICATIONS_NAMESPACE}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -149,7 +149,6 @@ dev:
     namespace: ${NOTIFICATIONS_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: notifications
-      app.kubernetes.io/instance: notifications
     containers:
       notifications:
         container: notifications

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
+	runnersv1 "github.com/agynio/notifications/internal/.gen/agynio/api/runners/v1"
+)
+
+// Authorizer is the subset of the Authorization service this server calls.
+type Authorizer interface {
+	Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
+}
+
+// WorkloadReader resolves the organization a workload belongs to. Workload
+// rooms are keyed by workload id, and the room's access check is stated against
+// that workload's organization.
+type WorkloadReader interface {
+	GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.GetWorkloadResponse, error)
+}
+
+// AgentReader resolves the organization an agent belongs to, for the same
+// reason as WorkloadReader.
+type AgentReader interface {
+	GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error)
+}
+
+const (
+	identityObjectPrefix     = "identity:"
+	organizationObjectPrefix = "organization:"
+
+	memberRelation           = "member"
+	canListSandboxesRelation = "can_list_sandboxes"
+)
+
+// requireOrganizationRelation resolves the caller's relation to an
+// organization. A failed lookup denies: a subscription outlives the request
+// that opened it, so anything short of a definite yes has to refuse.
+func (s *Server) requireOrganizationRelation(ctx context.Context, caller uuid.UUID, organizationID uuid.UUID, relation string) error {
+	if s.authz == nil {
+		return status.Error(codes.Internal, "authorization is not configured")
+	}
+	response, err := s.authz.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityObjectPrefix + caller.String(),
+			Relation: relation,
+			Object:   organizationObjectPrefix + organizationID.String(),
+		},
+	})
+	if err != nil {
+		s.logger.Warn("subscribe authorization check failed")
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	if !response.GetAllowed() {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return nil
+}
+
+// workloadOrganization reads the organization owning a workload. Notifications
+// forwards no identity here: it is an internal caller, gated by the mesh
+// policy, and the workload's organization is what the caller's access is then
+// checked against.
+func (s *Server) workloadOrganization(ctx context.Context, workloadID uuid.UUID) (uuid.UUID, error) {
+	if s.workloads == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "runners client is not configured")
+	}
+	response, err := s.workloads.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
+	if err != nil {
+		s.logger.Warn("subscribe workload lookup failed")
+		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return parseOrganization(response.GetWorkload().GetOrganizationId())
+}
+
+// agentOrganization reads the organization owning an agent, for the same reason
+// as workloadOrganization.
+func (s *Server) agentOrganization(ctx context.Context, agentID uuid.UUID) (uuid.UUID, error) {
+	if s.agents == nil {
+		return uuid.UUID{}, status.Error(codes.Internal, "agents client is not configured")
+	}
+	response, err := s.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID.String()})
+	if err != nil {
+		s.logger.Warn("subscribe agent lookup failed")
+		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return parseOrganization(response.GetAgent().GetOrganizationId())
+}
+
+func parseOrganization(value string) (uuid.UUID, error) {
+	id, err := parseUUID(value)
+	if err != nil {
+		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return id, nil
+}

--- a/internal/server/rooms.go
+++ b/internal/server/rooms.go
@@ -19,6 +19,10 @@ const (
 	organizationRoomPrefix      = "organization:"
 	agentRoomPrefix             = "agent:"
 	traceRoomPrefix             = "trace:"
+	sandboxOwnerRoomPrefix      = "sandbox_owner:"
+	sandboxOrgRoomPrefix        = "sandbox_org:"
+	volumeRoomPrefix            = "volume:"
+	egressRulesRoom             = "egress_rules"
 	selfRoomIDSegment           = "me"
 )
 
@@ -32,6 +36,10 @@ const (
 	roomKindOrganization
 	roomKindAgent
 	roomKindTrace
+	roomKindSandboxOwner
+	roomKindSandboxOrg
+	roomKindVolume
+	roomKindEgressRules
 )
 
 type subscriptionRoom struct {
@@ -88,6 +96,9 @@ func roomNames(rooms []subscriptionRoom) []string {
 }
 
 func classifyRoom(room string, callerID uuid.UUID) (roomKind, uuid.UUID, string, string, error) {
+	if room == egressRulesRoom {
+		return roomKindEgressRules, uuid.UUID{}, "", egressRulesRoom, nil
+	}
 	if strings.HasPrefix(room, threadParticipantRoomPrefix) {
 		raw := strings.TrimSpace(strings.TrimPrefix(room, threadParticipantRoomPrefix))
 		if raw == selfRoomIDSegment {
@@ -133,6 +144,24 @@ func classifyRoom(room string, callerID uuid.UUID) (roomKind, uuid.UUID, string,
 			return roomKindAgent, uuid.UUID{}, "", "", fmt.Errorf("agent: %w", err)
 		}
 		return roomKindAgent, id, "", agentRoomPrefix + id.String(), nil
+	}
+	if id, matched, err := parseRoomUUID(room, sandboxOwnerRoomPrefix); matched {
+		if err != nil {
+			return roomKindSandboxOwner, uuid.UUID{}, "", "", fmt.Errorf("sandbox_owner: %w", err)
+		}
+		return roomKindSandboxOwner, id, "", sandboxOwnerRoomPrefix + id.String(), nil
+	}
+	if id, matched, err := parseRoomUUID(room, sandboxOrgRoomPrefix); matched {
+		if err != nil {
+			return roomKindSandboxOrg, uuid.UUID{}, "", "", fmt.Errorf("sandbox_org: %w", err)
+		}
+		return roomKindSandboxOrg, id, "", sandboxOrgRoomPrefix + id.String(), nil
+	}
+	if id, matched, err := parseRoomUUID(room, volumeRoomPrefix); matched {
+		if err != nil {
+			return roomKindVolume, uuid.UUID{}, "", "", fmt.Errorf("volume: %w", err)
+		}
+		return roomKindVolume, id, "", volumeRoomPrefix + id.String(), nil
 	}
 	if traceID, matched, err := parseRoomTraceID(room); matched {
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,8 +60,23 @@ type Server struct {
 	logger      *zap.Logger
 	publisher   Publisher
 	hub         SubscriptionHub
+	authz       Authorizer
+	workloads   WorkloadReader
+	agents      AgentReader
 	clock       Clock
 	idGenerator IDGenerator
+}
+
+// WithAuthorization supplies the clients Subscribe needs to decide who may
+// listen to an entity's room: the Authorization service, plus the two services
+// that own the entities whose rooms are keyed by something other than an
+// organization.
+func WithAuthorization(authz Authorizer, workloads WorkloadReader, agents AgentReader) Option {
+	return func(s *Server) {
+		s.authz = authz
+		s.workloads = workloads
+		s.agents = agents
+	}
 }
 
 // New constructs a Server with the provided dependencies.
@@ -154,7 +169,11 @@ func callerIdentityFromContext(ctx context.Context) (callerIdentity, error) {
 	return callerIdentity{id: identityID, identityType: identityTypeFromContext(ctx)}, nil
 }
 
-func authorizeSubscribeRooms(caller callerIdentity, rooms []subscriptionRoom) error {
+// authorizeSubscribeRooms applies the room access table in
+// architecture/authz.md#notifications-service. Identity-keyed rooms are settled
+// by equality; every other room is gated on the caller's relation to the
+// organization that owns the entity the room reports on.
+func (s *Server) authorizeSubscribeRooms(ctx context.Context, caller callerIdentity, rooms []subscriptionRoom) error {
 	for _, room := range rooms {
 		switch room.kind {
 		case roomKindThreadParticipant:
@@ -165,6 +184,52 @@ func authorizeSubscribeRooms(caller callerIdentity, rooms []subscriptionRoom) er
 			if room.id != caller.id || caller.identityType != agentInstanceIdentityType {
 				return status.Error(codes.PermissionDenied, "permission denied")
 			}
+		case roomKindSandboxOwner:
+			// Only the owner, and ":me" is deliberately not accepted here.
+			if room.id != caller.id {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			}
+		case roomKindOrganization:
+			if err := s.requireOrganizationRelation(ctx, caller.id, room.id, memberRelation); err != nil {
+				return err
+			}
+		case roomKindSandboxOrg:
+			if err := s.requireOrganizationRelation(ctx, caller.id, room.id, canListSandboxesRelation); err != nil {
+				return err
+			}
+		case roomKindWorkload:
+			organizationID, err := s.workloadOrganization(ctx, room.id)
+			if err != nil {
+				return err
+			}
+			if err := s.requireOrganizationRelation(ctx, caller.id, organizationID, memberRelation); err != nil {
+				return err
+			}
+		case roomKindAgent:
+			organizationID, err := s.agentOrganization(ctx, room.id)
+			if err != nil {
+				return err
+			}
+			if err := s.requireOrganizationRelation(ctx, caller.id, organizationID, memberRelation); err != nil {
+				return err
+			}
+		case roomKindEgressRules:
+			// One global room, carrying rule invalidations to the Egress
+			// Gateway. It is not organization-keyed the way authz.md describes
+			// -- publisher and subscriber both use the bare literal -- so there
+			// is no organization to check against. Named here so the default
+			// below does not silently cut the gateway off.
+		case roomKindTrace, roomKindVolume:
+			// Both are specified as "member on the owning organization", and
+			// neither owner will say which organization that is: GetTrace
+			// returns raw OTLP spans, and neither the agents nor the runners
+			// Volume message carries an organization id. Closing these needs
+			// that field, so they stay open rather than break the console.
+		default:
+			// Unrecognised. Nothing publishes to it, so a subscription can only
+			// be a probe, and a room kind added later has to state its policy
+			// here rather than inherit an accidental allow.
+			return status.Error(codes.PermissionDenied, "permission denied")
 		}
 	}
 	return nil
@@ -182,7 +247,7 @@ func (s *Server) Subscribe(req *notificationsv1.SubscribeRequest, stream notific
 	if err != nil {
 		return err
 	}
-	if err := authorizeSubscribeRooms(caller, rooms); err != nil {
+	if err := s.authorizeSubscribeRooms(ctx, caller, rooms); err != nil {
 		return err
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,7 +21,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	agentsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/notifications/internal/.gen/agynio/api/authorization/v1"
 	notificationsv1 "github.com/agynio/notifications/internal/.gen/agynio/api/notifications/v1"
+	runnersv1 "github.com/agynio/notifications/internal/.gen/agynio/api/runners/v1"
 	"github.com/agynio/notifications/internal/server"
 	"github.com/agynio/notifications/internal/stream"
 )
@@ -417,7 +420,9 @@ func TestSubscribeWorkloadRoom(t *testing.T) {
 	}
 }
 
-func TestSubscribeUnknownRoomAllowed(t *testing.T) {
+// A room outside the table in architecture/authz.md has no publisher, so a
+// subscription to one can only be a probe.
+func TestSubscribeUnknownRoomDenied(t *testing.T) {
 	t.Parallel()
 
 	hub := stream.NewHub(2, zap.NewNop())
@@ -431,29 +436,59 @@ func TestSubscribeUnknownRoomAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Subscribe returned error: %v", err)
 	}
-
-	envelope := &notificationsv1.NotificationEnvelope{
-		Id:     uuid.NewString(),
-		Ts:     timestamppb.Now(),
-		Event:  "evt",
-		Source: "src",
-		Rooms:  []string{"project:unknown"},
-		Payload: &structpb.Struct{Fields: map[string]*structpb.Value{
-			"value": structpb.NewNumberValue(1),
-		}},
+	if _, err := streamClient.Recv(); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
 	}
+}
 
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		hub.Broadcast(envelope)
-	}()
+// A caller with no relation to the organization owning the entity is refused,
+// even though the room itself is well formed.
+func TestSubscribeDeniesUnrelatedCaller(t *testing.T) {
+	t.Parallel()
 
-	msg, err := streamClient.Recv()
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub, server.WithAuthorization(denyAll{}, denyAll{}, denyAll{}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContext(uuid.New()), time.Second)
+	defer cancel()
+
+	for _, room := range []string{
+		"organization:" + uuid.NewString(),
+		"sandbox_org:" + uuid.NewString(),
+		"workload:" + uuid.NewString(),
+		"agent:" + uuid.NewString(),
+	} {
+		streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{Rooms: []string{room}})
+		if err != nil {
+			t.Fatalf("Subscribe(%s) returned error: %v", room, err)
+		}
+		if _, err := streamClient.Recv(); status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("%s: expected PermissionDenied, got %v (%v)", room, status.Code(err), err)
+		}
+	}
+}
+
+// Sandbox owner rooms are identity equality, with no authorization call at all,
+// so a permissive authorizer must not make someone else's room readable.
+func TestSubscribeSandboxOwnerRoomIsOwnerOnly(t *testing.T) {
+	t.Parallel()
+
+	hub := stream.NewHub(2, zap.NewNop())
+	client, cleanup := startTestServer(t, &publisherStub{}, hub)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContext(uuid.New()), time.Second)
+	defer cancel()
+
+	streamClient, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{
+		Rooms: []string{"sandbox_owner:" + uuid.NewString()},
+	})
 	if err != nil {
-		t.Fatalf("Recv returned error: %v", err)
+		t.Fatalf("Subscribe returned error: %v", err)
 	}
-	if !proto.Equal(envelope, msg.GetEnvelope()) {
-		t.Fatalf("unexpected envelope: %+v", msg.GetEnvelope())
+	if _, err := streamClient.Recv(); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
 	}
 }
 
@@ -753,11 +788,39 @@ func (n *noopHub) Subscribe(_ []string) (<-chan *notificationsv1.NotificationEnv
 	return ch, func() { close(ch) }
 }
 
+// allowAll answers every authorization check yes and reports a fixed
+// organization for any entity.
+type allowAll struct{}
+
+func (allowAll) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return &authorizationv1.CheckResponse{Allowed: true}, nil
+}
+
+func (allowAll) GetWorkload(_ context.Context, _ *runnersv1.GetWorkloadRequest, _ ...grpc.CallOption) (*runnersv1.GetWorkloadResponse, error) {
+	return &runnersv1.GetWorkloadResponse{Workload: &runnersv1.Workload{OrganizationId: uuid.NewString()}}, nil
+}
+
+func (allowAll) GetAgent(_ context.Context, _ *agentsv1.GetAgentRequest, _ ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+	return &agentsv1.GetAgentResponse{Agent: &agentsv1.Agent{OrganizationId: uuid.NewString()}}, nil
+}
+
+// denyAll refuses every check but still resolves organizations, so a test can
+// tell "the caller has no relation" apart from "the lookup failed".
+type denyAll struct{ allowAll }
+
+func (denyAll) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return &authorizationv1.CheckResponse{Allowed: false}, nil
+}
+
 func startTestServer(t *testing.T, publisher server.Publisher, hub server.SubscriptionHub, opts ...server.Option) (notificationsv1.NotificationsServiceClient, func()) {
 	t.Helper()
 
 	listener := bufconn.Listen(bufSize)
 	grpcServer := grpc.NewServer()
+	// Permissive by default so tests that are not about authorization keep
+	// exercising what they were written for; a test that cares passes its own
+	// WithAuthorization, which applies after these and wins.
+	opts = append([]server.Option{server.WithAuthorization(allowAll{}, allowAll{}, allowAll{})}, opts...)
 	notificationsv1.RegisterNotificationsServiceServer(grpcServer, server.New(publisher, hub, zap.NewNop(), opts...))
 
 	go func() {


### PR DESCRIPTION
Deploying this service from source into the platform VM hangs:

```
DevSpace still couldn't find any Pods that match the selector
```

The `dev` selector paired `app.kubernetes.io/name` with `app.kubernetes.io/instance=<service>`. That held when every service was its own Helm release. The **agyn-platform umbrella** makes the instance label its own release name, so the selector matches nothing — verified against a running VM, where the pod carries `app.kubernetes.io/instance: agyn-platform`.

The pod starts and spins waiting for a binary the sync never delivers, and the deploy times out having already patched a Deployment it cannot reach.

The `name` label alone is unique in the namespace and is correct under both layouts. Same fix as the E2E workflow’s own selectors.