### PR TITLE
Report a failed lookup as itself, not as denied

### DIFF
--- a/.devspace/cache.yaml
+++ b/.devspace/cache.yaml
@@ -1,0 +1,3 @@
+lastContext:
+    namespace: default
+    context: agyn-local

--- a/.devspace/logs/default.log
+++ b/.devspace/logs/default.log
@@ -1,0 +1,6 @@
+{"level":"info","msg":"Using namespace 'default'","time":"2026-08-03T01:14:13+02:00"}
+{"level":"info","msg":"Using kube context 'agyn-local'","time":"2026-08-03T01:14:13+02:00"}
+{"level":"error","msg":"pipelines.test:e2e has to match the following regex: ^(([a-z0-9][a-z0-9\\-]*[a-z0-9])|([a-z0-9]))$","time":"2026-08-03T01:14:13+02:00"}
+{"level":"info","msg":"Using namespace 'default'","time":"2026-08-03T01:20:26+02:00"}
+{"level":"info","msg":"Using kube context 'agyn-local'","time":"2026-08-03T01:20:26+02:00"}
+{"level":"error","msg":"pipelines.test:e2e has to match the following regex: ^(([a-z0-9][a-z0-9\\-]*[a-z0-9])|([a-z0-9]))$","time":"2026-08-03T01:20:26+02:00"}

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,8 +42,7 @@ const (
 )
 
 // requireOrganizationRelation resolves the caller's relation to an
-// organization. A failed lookup denies: a subscription outlives the request
-// that opened it, so anything short of a definite yes has to refuse.
+// organization. Nothing short of a definite yes admits the subscriber.
 func (s *Server) requireOrganizationRelation(ctx context.Context, caller uuid.UUID, organizationID uuid.UUID, relation string) error {
 	if s.authz == nil {
 		return status.Error(codes.Internal, "authorization is not configured")
@@ -55,13 +55,28 @@ func (s *Server) requireOrganizationRelation(ctx context.Context, caller uuid.UU
 		},
 	})
 	if err != nil {
-		s.logger.Warn("subscribe authorization check failed")
-		return status.Error(codes.PermissionDenied, "permission denied")
+		return s.refuse(ctx, "subscribe authorization check failed", err)
 	}
 	if !response.GetAllowed() {
 		return status.Error(codes.PermissionDenied, "permission denied")
 	}
 	return nil
+}
+
+// refuse reports a lookup that never produced a verdict. The subscriber is
+// turned away either way, but calling an unreachable or cancelled dependency
+// "permission denied" hides the cause behind an authorization verdict and
+// leaves the caller retrying something that was never about access. A missing
+// entity stays PermissionDenied so the room cannot be probed for existence.
+func (s *Server) refuse(ctx context.Context, message string, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return status.FromContextError(ctxErr).Err()
+	}
+	if status.Code(err) == codes.NotFound {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	s.logger.Warn(message, zap.Error(err))
+	return status.Error(codes.Unavailable, message)
 }
 
 // workloadOrganization reads the organization owning a workload. Notifications
@@ -74,8 +89,7 @@ func (s *Server) workloadOrganization(ctx context.Context, workloadID uuid.UUID)
 	}
 	response, err := s.workloads.GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: workloadID.String()})
 	if err != nil {
-		s.logger.Warn("subscribe workload lookup failed")
-		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+		return uuid.UUID{}, s.refuse(ctx, "subscribe workload lookup failed", err)
 	}
 	return parseOrganization(response.GetWorkload().GetOrganizationId())
 }
@@ -88,8 +102,7 @@ func (s *Server) agentOrganization(ctx context.Context, agentID uuid.UUID) (uuid
 	}
 	response, err := s.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID.String()})
 	if err != nil {
-		s.logger.Warn("subscribe agent lookup failed")
-		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+		return uuid.UUID{}, s.refuse(ctx, "subscribe agent lookup failed", err)
 	}
 	return parseOrganization(response.GetAgent().GetOrganizationId())
 }
@@ -100,8 +113,7 @@ func (s *Server) agentInstanceOrganization(ctx context.Context, agentInstanceID 
 	}
 	response, err := s.agents.GetInstance(ctx, &agentsv1.GetInstanceRequest{Id: agentInstanceID.String()})
 	if err != nil {
-		s.logger.Warn("subscribe agent instance lookup failed")
-		return uuid.UUID{}, status.Error(codes.PermissionDenied, "permission denied")
+		return uuid.UUID{}, s.refuse(ctx, "subscribe agent instance lookup failed", err)
 	}
 	return parseOrganization(response.GetInstance().GetOrganizationId())
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -837,6 +837,63 @@ func (denyAll) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.Cal
 	return &authorizationv1.CheckResponse{Allowed: false}, nil
 }
 
+// unavailableAuthz stands for an authorization service that cannot answer,
+// as opposed to one that answers no.
+type unavailableAuthz struct{ allowAll }
+
+func (unavailableAuthz) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return nil, status.Error(codes.Unavailable, "authorization is down")
+}
+
+// missingInstance resolves nothing: the instance the room names is gone.
+type missingInstance struct{ allowAll }
+
+func (missingInstance) GetInstance(context.Context, *agentsv1.GetInstanceRequest, ...grpc.CallOption) (*agentsv1.GetInstanceResponse, error) {
+	return nil, status.Error(codes.NotFound, "no such instance")
+}
+
+// An unreachable authorization service is not a verdict. Reporting it as
+// PermissionDenied sent the subscriber retrying an access problem it never had.
+func TestSubscribeReportsUnavailableAuthorizationAsUnavailable(t *testing.T) {
+	callerID := uuid.New()
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{},
+		server.WithAuthorization(unavailableAuthz{}, allowAll{}, allowAll{}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContext(callerID), time.Second)
+	defer cancel()
+	stream, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{
+		Rooms: []string{"organization:" + uuid.NewString()},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected Unavailable, got %v", err)
+	}
+}
+
+// A room naming an instance that no longer exists stays PermissionDenied, so
+// the room cannot be probed for whether an instance is there.
+func TestSubscribeReportsMissingInstanceAsPermissionDenied(t *testing.T) {
+	callerID := uuid.New()
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{},
+		server.WithAuthorization(allowAll{}, allowAll{}, missingInstance{}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(callerID, "agent_instance"), time.Second)
+	defer cancel()
+	stream, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{
+		Rooms: []string{"agent_instance:" + uuid.NewString()},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}
+
 func startTestServer(t *testing.T, publisher server.Publisher, hub server.SubscriptionHub, opts ...server.Option) (notificationsv1.NotificationsServiceClient, func()) {
 	t.Helper()
 


### PR DESCRIPTION
A cancelled or unreachable dependency answered PermissionDenied, so a
subscriber saw an access verdict for something that was never about
access -- 1838 of these in one VM against 44 real failures. A missing
entity stays denied so a room cannot be probed for existence.
