### PR TITLE
Let an instance watch its own room

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -211,6 +211,15 @@ func (s *Server) authorizeSubscribeRooms(ctx context.Context, caller callerIdent
 		// through its own org relation, which is how the Orchestrator watches
 		// the instances it reconciles.
 		case roomKindAgentInstance:
+			// The instance watching itself is settled by identity, as its inbox
+			// room already is. An instance is not a member of its organization,
+			// so requiring that relation denied the Orchestrator every time it
+			// subscribed as one -- it then saw no wake, and a message that
+			// arrived after the workload had synced its inbox was never
+			// delivered.
+			if room.id == caller.id && caller.identityType == agentInstanceIdentityType {
+				continue
+			}
 			organizationID, err := s.agentInstanceOrganization(ctx, room.id)
 			if err != nil {
 				return err

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -894,6 +894,46 @@ func TestSubscribeReportsMissingInstanceAsPermissionDenied(t *testing.T) {
 	}
 }
 
+// An instance is not a member of its organization, so gating its own room on
+// that relation denied the Orchestrator every subscription it opened as one.
+func TestSubscribeAllowsAnInstanceToWatchItsOwnRoom(t *testing.T) {
+	instanceID := uuid.New()
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{},
+		server.WithAuthorization(denyAll{}, allowAll{}, allowAll{}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(instanceID, "agent_instance"), 500*time.Millisecond)
+	defer cancel()
+	stream, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{
+		Rooms: []string{"agent_instance:" + instanceID.String()},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) == codes.PermissionDenied {
+		t.Fatal("an instance was denied its own room")
+	}
+}
+
+// Another instance's room is still gated on organization membership.
+func TestSubscribeDeniesAnInstanceAnotherInstancesRoom(t *testing.T) {
+	client, cleanup := startTestServer(t, &publisherStub{}, &noopHub{},
+		server.WithAuthorization(denyAll{}, allowAll{}, allowAll{}))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(authenticatedContextWithType(uuid.New(), "agent_instance"), time.Second)
+	defer cancel()
+	stream, err := client.Subscribe(ctx, &notificationsv1.SubscribeRequest{
+		Rooms: []string{"agent_instance:" + uuid.NewString()},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}
+
 func startTestServer(t *testing.T, publisher server.Publisher, hub server.SubscriptionHub, opts ...server.Option) (notificationsv1.NotificationsServiceClient, func()) {
 	t.Helper()
 


### PR DESCRIPTION
An agent instance is not a member of its organization, so gating the `agent_instance` room on that relation denied the Orchestrator every subscription it opened as one. With no wake, a message arriving after the workload synced its inbox was never delivered and the agent sat idle. Settled by identity, as the instance's inbox room already is.