### PR TITLE
Register the two flat native-mode rooms

### DIFF
--- a/internal/server/rooms.go
+++ b/internal/server/rooms.go
@@ -24,6 +24,8 @@ const (
 	sandboxOrgRoomPrefix        = "sandbox_org:"
 	volumeRoomPrefix            = "volume:"
 	egressRulesRoom             = "egress_rules"
+	llmSubscriptionsRoom        = "llm_subscriptions"
+	environmentsRoom            = "environments"
 	selfRoomIDSegment           = "me"
 )
 
@@ -42,6 +44,8 @@ const (
 	roomKindSandboxOrg
 	roomKindVolume
 	roomKindEgressRules
+	roomKindLLMSubscriptions
+	roomKindEnvironments
 )
 
 type subscriptionRoom struct {
@@ -100,6 +104,12 @@ func roomNames(rooms []subscriptionRoom) []string {
 func classifyRoom(room string, callerID uuid.UUID) (roomKind, uuid.UUID, string, string, error) {
 	if room == egressRulesRoom {
 		return roomKindEgressRules, uuid.UUID{}, "", egressRulesRoom, nil
+	}
+	if room == llmSubscriptionsRoom {
+		return roomKindLLMSubscriptions, uuid.UUID{}, "", llmSubscriptionsRoom, nil
+	}
+	if room == environmentsRoom {
+		return roomKindEnvironments, uuid.UUID{}, "", environmentsRoom, nil
 	}
 	if strings.HasPrefix(room, threadParticipantRoomPrefix) {
 		raw := strings.TrimSpace(strings.TrimPrefix(room, threadParticipantRoomPrefix))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,6 +241,13 @@ func (s *Server) authorizeSubscribeRooms(ctx context.Context, caller callerIdent
 			// -- publisher and subscriber both use the bare literal -- so there
 			// is no organization to check against. Named here so the default
 			// below does not silently cut the gateway off.
+		case roomKindLLMSubscriptions, roomKindEnvironments:
+			// The same shape as egress_rules and for the same reason: the LLM
+			// Proxy caches a native-mode binding on a connection and cannot
+			// enumerate the organizations or environments it will serve, so a
+			// per-organization room would leave it re-subscribing forever or
+			// missing invalidations for one it has not seen. Bare literals with
+			// no organization to check against.
 		case roomKindTrace, roomKindVolume:
 			// Both are specified as "member on the owning organization", and
 			// neither owner will say which organization that is: GetTrace


### PR DESCRIPTION
llm_subscriptions and environments carry native-mode invalidations to the LLM Proxy. Unregistered they fell to the default deny, which is the policy that branch exists to enforce — a room kind added later has to state its policy rather than inherit an accidental allow.

Same shape as egress_rules and for the same reason: the proxy caches a binding on a connection and cannot enumerate the organizations or environments it will serve, so a per-organization room would leave it re-subscribing forever or missing invalidations for one it has not seen.

Also repairs devspace.yaml, which could not be loaded at all: a pipeline and command named test:e2e fail DevSpace's naming rule, and the dev patch left the chart's probes in place, so the container was killed a minute in while waiting for its source.

Part of native LLM mode.